### PR TITLE
Add gicisky integration to home assistant

### DIFF
--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -30,6 +30,8 @@ ENV \
     CUSTOM_COMPONENT_HOME_CONNECT_VERSION=1.2.1 \
       # renovatebot: datasource=github-releases depName=smartHomeHub/SmartIR
     CUSTOM_COMPONENT_SMARTIR_VERSION=1.18.1 \
+      # renovatebot: datasource=github-releases depName=eigger/hass-gicisky
+    CUSTOM_COMPONENT_GICISKY_VERSION=1.2.6 \
       # renovatebot: datasource=github-releases depName=PiotrMachowski/lovelace-xiaomi-vacuum-map-card
     CUSTOM_CARD_XIAOMI_VACUUM_MAP_VERSION=v2.3.1 \
       # renovatebot: datasource=github-releases depName=Hypfer/lovelace-valetudo-map-card
@@ -99,6 +101,10 @@ RUN \
     && git clone https://github.com/smartHomeHub/SmartIR.git /tmp/smartir \
     && cd /tmp/smartir && git checkout $CUSTOM_COMPONENT_SMARTIR_VERSION \
     && cd - && cp -r /tmp/smartir/custom_components/smartir /opt/HA/config/custom_components/ \
+    # gicisky
+    && git clone https://github.com/eigger/hass-gicisky.git /tmp/hass-gicisky \
+    && cd /tmp/hass-gicisky && git checkout $CUSTOM_COMPONENT_GICISKY_VERSION \
+    && cd - && cp -r /tmp/hass-gicisky/custom_components/gicisky /opt/HA/config/custom_components/ \
     ## ----------  Cards  ----------
     && mkdir -p /HA-custom-www/external-cards/ \
     # Xiaomi vacuum map card

--- a/home_automation/home_assistant/config/configuration.yaml
+++ b/home_automation/home_assistant/config/configuration.yaml
@@ -161,6 +161,10 @@ smartir:
   # Home Assistant integration to manage climate systems, TVs, fans and lights using IR/RF controllers
   check_updates: false
 
+gicisky:
+  # https://github.com/eigger/hass-gicisky
+  # Gicisky BLE Label Home Assistant Integration
+
 # Text to speech
 tts:
   - platform: google_translate

--- a/home_automation/home_assistant/config/packages/gicisky/README.md
+++ b/home_automation/home_assistant/config/packages/gicisky/README.md
@@ -1,0 +1,48 @@
+# Gicisky BLE Label Integration
+
+This package contains configuration for the Gicisky BLE Label integration in Home Assistant.
+
+## What is Gicisky?
+
+Gicisky is a BLE (Bluetooth Low Energy) electronic label system that can display text, images, and other content. This integration allows you to control Gicisky labels from Home Assistant.
+
+## Setup
+
+1. The integration is automatically installed via the Dockerfile
+2. The integration is enabled in the main configuration.yaml
+3. You need to discover and pair your Gicisky devices
+4. Replace `YOUR_GICISKY_DEVICE_ID_HERE` in the example configuration with your actual device ID
+
+## Features
+
+- Display text with custom fonts, colors, and positioning
+- Display images
+- Update content automatically based on Home Assistant entities
+- Support for different label sizes (2.1", 4.2", 7.5")
+
+## Example Configurations
+
+### Date Display
+The `example_label.yaml` file shows how to display the current date and day of the week on a Gicisky label.
+
+### Weather Display
+You can create automations to display weather information, calendar events, or any other Home Assistant data.
+
+## Device Discovery
+
+To find your Gicisky device ID:
+1. Enable the integration in Home Assistant
+2. Check the Home Assistant logs for discovered devices
+3. Use the device ID in your automation configurations
+
+## Documentation
+
+For more information, visit the [official repository](https://github.com/eigger/hass-gicisky).
+
+## Supported Label Models
+
+- 2.1" labels
+- 4.2" labels  
+- 7.5" labels
+
+Each model has different resolution and capabilities. Check the examples in the official repository for model-specific configurations.

--- a/home_automation/home_assistant/config/packages/gicisky/example_label.yaml
+++ b/home_automation/home_assistant/config/packages/gicisky/example_label.yaml
@@ -1,0 +1,37 @@
+# Example Gicisky BLE Label Configuration
+# This is an example configuration for a Gicisky label that displays the current date
+# Replace the device_id with your actual Gicisky device ID
+
+alias: "Gicisky Date Label Example"
+description: "Example automation to display current date on Gicisky label"
+triggers:
+  - trigger: time
+    at: "00:00:00"
+  - trigger: time_pattern
+    minutes: "/30"
+conditions: []
+actions:
+  - action: gicisky.write
+    data:
+      payload:
+        - type: text
+          value: "{{ now().strftime('%m/%d') }}"
+          font: fonts/arial.ttf
+          anchor: mt
+          x: 125
+          y: 10
+          size: 45
+          color: black
+        - type: text
+          value: "{{ now().strftime('%A') }}"
+          font: fonts/arial.ttf
+          anchor: mb
+          x: 125
+          y: 108
+          size: 35
+          color: |
+            {% set date = now().strftime('%A') %}
+            {{ 'red' if date == 'Saturday' or date == 'Sunday' else 'black' }}
+    target:
+      device_id: YOUR_GICISKY_DEVICE_ID_HERE
+mode: single


### PR DESCRIPTION
Add Gicisky BLE Label integration to Home Assistant to control electronic labels.