### PR TITLE
Update Home Assistant and browser_mod versions

### DIFF
--- a/home_automation/docker-compose.yml
+++ b/home_automation/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             - "traefik.http.routers.home-assistant.tls.domains[0].sans=${EXTERNAL_WILDCARD_DOMAIN}"
 
     esphome:
-        image: esphome/esphome:2025.12.7
+        image: esphome/esphome:2026.3.0
         restart: unless-stopped
         # ports:
         #     - 0.0.0.0:6052:6052

--- a/home_automation/docker-compose.yml
+++ b/home_automation/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             - "traefik.http.routers.home-assistant.tls.domains[0].sans=${EXTERNAL_WILDCARD_DOMAIN}"
 
     esphome:
-        image: esphome/esphome:2026.3.0
+        image: esphome/esphome:2025.12.7
         restart: unless-stopped
         # ports:
         #     - 0.0.0.0:6052:6052

--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/home-assistant:2026.1.3
+FROM ghcr.io/home-assistant/home-assistant:2026.2.3
 
 ##### Pending tasks
 # - Redo all scripts/automations with the news if/else/then, for each, continue on error, parallelize
@@ -15,7 +15,7 @@ ENV \
     #   # renovatebot: datasource=github-releases depName=custom-components/ble_monitor
     # CUSTOM_COMPONENT_BLE_MONITOR_VERSION=9.2.0 \
       # renovatebot: datasource=github-releases depName=thomasloven/hass-browser_mod versioning=semver
-    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v2.7.0 \
+    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v2.7.4 \
       # renovatebot: datasource=github-releases depName=leikoilja/ha-google-home
     CUSTOM_COMPONENT_GOOGLE_HOME_VERSION=v1.13.3 \
       # renovatebot: datasource=github-releases depName=PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor


### PR DESCRIPTION
## Summary
This PR updates the base Home Assistant image and a custom component dependency to their latest versions.

## Key Changes
- Upgraded Home Assistant base image from `2026.1.3` to `2026.2.3`
- Updated browser_mod custom component from `v2.7.0` to `v2.7.4`

## Details
These are routine dependency updates to bring the Home Assistant installation to the latest available versions, ensuring access to the latest features, bug fixes, and security patches.

https://claude.ai/code/session_014HNnFMMUbexPYEd42JRJ6Y