### PR TITLE
Add Mushroom cards integration and enhance UI with custom cards

### DIFF
--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -47,7 +47,9 @@ ENV \
       # renovatebot: datasource=github-releases depName=marrobHD/tv-card
     CUSTOM_CARD_TV_REMOTE_VERSION=v0.2.1 \
       # renovatebot: datasource=github-releases depName=DurgNomis-drol/google_home_timers_card
-    CUSTOM_CARD_GOOGLE_HOME_TIMERS_VERSION=v0.2.0
+    CUSTOM_CARD_GOOGLE_HOME_TIMERS_VERSION=v0.2.0 \
+      # renovatebot: datasource=github-releases depName=piitaya/lovelace-mushroom
+    CUSTOM_CARD_MUSHROOM_VERSION=v5.1.1
 
 ENV \
     CUSTOM_CARD_XIAOMI_VACUUM_MAP_PATH=/local/external-cards/xiaomi-vacuum-map-card.js?version=${CUSTOM_CARD_XIAOMI_VACUUM_MAP_VERSION} \
@@ -56,7 +58,8 @@ ENV \
     CUSTOM_CARD_MINI_GRAPH_PATH=/local/external-cards/mini-graph-card-bundle.js?version=${CUSTOM_CARD_MINI_GRAPH_VERSION} \
     CUSTOM_CARD_APEXCHARTS_PATH=/local/external-cards/apexcharts-card.js?version=${CUSTOM_CARD_APEXCHARTS_VERSION} \
     CUSTOM_CARD_TV_REMOTE_PATH=/local/external-cards/tv-card.js?version=${CUSTOM_CARD_TV_REMOTE_VERSION} \
-    CUSTOM_CARD_GOOGLE_HOME_TIMERS_PATH=/local/external-cards/googletimers-card.js?version=${CUSTOM_CARD_GOOGLE_HOME_TIMERS_VERSION}
+    CUSTOM_CARD_GOOGLE_HOME_TIMERS_PATH=/local/external-cards/googletimers-card.js?version=${CUSTOM_CARD_GOOGLE_HOME_TIMERS_VERSION} \
+    CUSTOM_CARD_MUSHROOM_PATH=/local/external-cards/mushroom.js?version=${CUSTOM_CARD_MUSHROOM_VERSION}
 
 RUN \
     set -ex \
@@ -136,6 +139,8 @@ RUN \
     && git clone https://github.com/DurgNomis-drol/google_home_timers_card.git /tmp/google_home_timers_card \
     && cd /tmp/google_home_timers_card && git checkout $CUSTOM_CARD_GOOGLE_HOME_TIMERS_VERSION \
     && cd - && cp -r /tmp/google_home_timers_card/googletimers-card.js /HA-custom-www/external-cards/ \
+    # Mushroom Cards
+    && curl -fsSL "https://github.com/piitaya/lovelace-mushroom/releases/download/${CUSTOM_CARD_MUSHROOM_VERSION}/mushroom.js" -o /HA-custom-www/external-cards/mushroom.js \
     && apk del build-dep
 
 RUN \

--- a/home_automation/home_assistant/config/configuration.yaml
+++ b/home_automation/home_assistant/config/configuration.yaml
@@ -68,6 +68,8 @@ lovelace:
       url: !env_var CUSTOM_CARD_TV_REMOTE_PATH
     - type: module
       url: !env_var CUSTOM_CARD_GOOGLE_HOME_TIMERS_PATH
+    - type: module
+      url: !env_var CUSTOM_CARD_MUSHROOM_PATH
 
 recorder:
   db_url: !secret recorder_db_url

--- a/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
@@ -45,7 +45,7 @@ entities:
     tap_action: !include ../utils/tv-card.yaml
   - entity: media_player.mini
     name: Mini (cocina)
-  - entity: sensor.dishwasher_status_operationstate
+  - entity: sensor.dishwasher_common_status_operationstate
     name: Lavavajillas
     icon: mdi:dishwasher
     tap_action: !include ../utils/dishwasher-card.yaml

--- a/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
@@ -45,8 +45,7 @@ entities:
     tap_action: !include ../utils/tv-card.yaml
   - entity: media_player.mini
     name: Mini (cocina)
-  # We should use the ID of the new integration but it contains serial id
-  - entity: sensor.lavavajillas_status_operationstate
+  - entity: sensor.dishwasher_status_operationstate
     name: Lavavajillas
     icon: mdi:dishwasher
     tap_action: !include ../utils/dishwasher-card.yaml

--- a/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
@@ -51,7 +51,7 @@ entities:
     tap_action: !include ../utils/dishwasher-card.yaml
     conditions:
       - condition: state
-        state_not: BSH.Common.EnumType.OperationState.Ready
+        state_not: Ready
   - entity: switch.adguard_protection
     name: AdGuard - Bloqueo de anuncios
     conditions:

--- a/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/005_turned-on_entities.yaml
@@ -49,6 +49,7 @@ entities:
   - entity: sensor.lavavajillas_status_operationstate
     name: Lavavajillas
     icon: mdi:dishwasher
+    tap_action: !include ../utils/dishwasher-card.yaml
     conditions:
       - condition: state
         state_not: BSH.Common.EnumType.OperationState.Ready

--- a/home_automation/home_assistant/config/ui-views/Home/010_people-location.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/010_people-location.yaml
@@ -3,14 +3,7 @@ cards:
   - type: custom:mushroom-template-card
     entity: sensor.manolo_status
     primary: Manolo
-    secondary: >
-      {% set s = states('sensor.manolo_status') %}
-      {% if   s == 'Home'          %}En casa
-      {% elif s == 'Just Arrived'  %}Acaba de llegar
-      {% elif s == 'Just Left'     %}Acaba de salir
-      {% elif s == 'Away'          %}Fuera
-      {% elif s == 'Extended Away' %}Fuera hace tiempo
-      {% else %}Desconocido{% endif %}
+    secondary: "{{ states('sensor.manolo_status') }}"
     icon: >
       {% set s = states('sensor.manolo_status') %}
       {% if   s == 'Home'          %}mdi:home
@@ -33,14 +26,7 @@ cards:
   - type: custom:mushroom-template-card
     entity: sensor.monica_status
     primary: Mónica
-    secondary: >
-      {% set s = states('sensor.monica_status') %}
-      {% if   s == 'Home'          %}En casa
-      {% elif s == 'Just Arrived'  %}Acaba de llegar
-      {% elif s == 'Just Left'     %}Acaba de salir
-      {% elif s == 'Away'          %}Fuera
-      {% elif s == 'Extended Away' %}Fuera hace tiempo
-      {% else %}Desconocido{% endif %}
+    secondary: "{{ states('sensor.monica_status') }}"
     icon: >
       {% set s = states('sensor.monica_status') %}
       {% if   s == 'Home'          %}mdi:home

--- a/home_automation/home_assistant/config/ui-views/Home/010_people-location.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/010_people-location.yaml
@@ -1,6 +1,14 @@
 type: horizontal-stack
 cards:
-  - type: tile
-    entity: sensor.manolo_status
-  - type: tile
-    entity: sensor.monica_status
+  - type: custom:mushroom-person-card
+    entity: person.manolo
+    icon: mdi:human-male
+    use_entity_picture: true
+    tap_action:
+      action: more-info
+  - type: custom:mushroom-person-card
+    entity: person.monica
+    icon: mdi:human-female
+    use_entity_picture: true
+    tap_action:
+      action: more-info

--- a/home_automation/home_assistant/config/ui-views/Home/010_people-location.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/010_people-location.yaml
@@ -1,14 +1,61 @@
 type: horizontal-stack
 cards:
-  - type: custom:mushroom-person-card
-    entity: person.manolo
-    icon: mdi:human-male
-    use_entity_picture: true
+  - type: custom:mushroom-template-card
+    entity: sensor.manolo_status
+    primary: Manolo
+    secondary: >
+      {% set s = states('sensor.manolo_status') %}
+      {% if   s == 'Home'          %}En casa
+      {% elif s == 'Just Arrived'  %}Acaba de llegar
+      {% elif s == 'Just Left'     %}Acaba de salir
+      {% elif s == 'Away'          %}Fuera
+      {% elif s == 'Extended Away' %}Fuera hace tiempo
+      {% else %}Desconocido{% endif %}
+    icon: >
+      {% set s = states('sensor.manolo_status') %}
+      {% if   s == 'Home'          %}mdi:home
+      {% elif s == 'Just Arrived'  %}mdi:home-import-outline
+      {% elif s == 'Just Left'     %}mdi:home-export-outline
+      {% elif s == 'Away'          %}mdi:map-marker-outline
+      {% elif s == 'Extended Away' %}mdi:map-marker-off-outline
+      {% else %}mdi:help-circle-outline{% endif %}
+    icon_color: >
+      {% set s = states('sensor.manolo_status') %}
+      {% if   s == 'Home'          %}green
+      {% elif s == 'Just Arrived'  %}light-green
+      {% elif s == 'Just Left'     %}orange
+      {% elif s == 'Away'          %}red
+      {% elif s == 'Extended Away' %}deep-orange
+      {% else %}disabled{% endif %}
     tap_action:
       action: more-info
-  - type: custom:mushroom-person-card
-    entity: person.monica
-    icon: mdi:human-female
-    use_entity_picture: true
+
+  - type: custom:mushroom-template-card
+    entity: sensor.monica_status
+    primary: Mónica
+    secondary: >
+      {% set s = states('sensor.monica_status') %}
+      {% if   s == 'Home'          %}En casa
+      {% elif s == 'Just Arrived'  %}Acaba de llegar
+      {% elif s == 'Just Left'     %}Acaba de salir
+      {% elif s == 'Away'          %}Fuera
+      {% elif s == 'Extended Away' %}Fuera hace tiempo
+      {% else %}Desconocido{% endif %}
+    icon: >
+      {% set s = states('sensor.monica_status') %}
+      {% if   s == 'Home'          %}mdi:home
+      {% elif s == 'Just Arrived'  %}mdi:home-import-outline
+      {% elif s == 'Just Left'     %}mdi:home-export-outline
+      {% elif s == 'Away'          %}mdi:map-marker-outline
+      {% elif s == 'Extended Away' %}mdi:map-marker-off-outline
+      {% else %}mdi:help-circle-outline{% endif %}
+    icon_color: >
+      {% set s = states('sensor.monica_status') %}
+      {% if   s == 'Home'          %}green
+      {% elif s == 'Just Arrived'  %}light-green
+      {% elif s == 'Just Left'     %}orange
+      {% elif s == 'Away'          %}red
+      {% elif s == 'Extended Away' %}deep-orange
+      {% else %}disabled{% endif %}
     tap_action:
       action: more-info

--- a/home_automation/home_assistant/config/ui-views/Home/020_home-map.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/020_home-map.yaml
@@ -13,6 +13,14 @@ elements:
       left: 65%
       "--state-icon-color": blue
   - type: state-icon
+    tap_action: !include ../utils/dishwasher-card.yaml
+    entity: sensor.lavavajillas_status_operationstate
+    icon: mdi:dishwasher
+    style:
+      top: 53%
+      left: 72%
+      "--state-icon-color": blue
+  - type: state-icon
     tap_action:
       action: more-info
     entity: group.man_003

--- a/home_automation/home_assistant/config/ui-views/Home/020_home-map.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/020_home-map.yaml
@@ -14,7 +14,7 @@ elements:
       "--state-icon-color": blue
   - type: state-icon
     tap_action: !include ../utils/dishwasher-card.yaml
-    entity: sensor.lavavajillas_status_operationstate
+    entity: sensor.dishwasher_status_operationstate
     icon: mdi:dishwasher
     style:
       top: 53%

--- a/home_automation/home_assistant/config/ui-views/Home/020_home-map.yaml
+++ b/home_automation/home_assistant/config/ui-views/Home/020_home-map.yaml
@@ -14,7 +14,7 @@ elements:
       "--state-icon-color": blue
   - type: state-icon
     tap_action: !include ../utils/dishwasher-card.yaml
-    entity: sensor.dishwasher_status_operationstate
+    entity: sensor.dishwasher_common_status_operationstate
     icon: mdi:dishwasher
     style:
       top: 53%

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -19,14 +19,7 @@ browser_mod:
 
         # ── Estado principal con color y texto dinámico ─────────────────────
         - type: custom:mushroom-template-card
-          primary: >
-            {% set s = states('sensor.lavavajillas_status_operationstate') %}
-            {% if   'Run'            in s %}En marcha
-            {% elif 'Finished'       in s %}¡Terminado! Puedes vaciarlo
-            {% elif 'Pause'          in s %}En pausa
-            {% elif 'ActionRequired' in s %}Acción requerida
-            {% elif 'Ready'          in s %}Listo
-            {% else %}{{ s }}{% endif %}
+          primary: "{{ states('sensor.lavavajillas_status_operationstate') }}"
           secondary: >
             {% set prog = states('sensor.lavavajillas_program_selected') %}
             {% set t    = states('sensor.lavavajillas_bsh_common_option_remainingprogramtime') %}

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -60,19 +60,25 @@ browser_mod:
             - entity: select.dishwasher_programs
               name: Programa
               icon: mdi:format-list-bulleted
-            - entity: time.dishwasher_common_option_startinrelative
-              name: Inicio retrasado
-              icon: mdi:clock-start
             - entity: sensor.dishwasher_common_option_remainingprogramtime
               name: Termina a las
               icon: mdi:clock-end
               format: time
-            - entity: sensor.dishwasher_common_option_energyforecast
-              name: Energía prevista
+
+        - type: custom:mushroom-chips-card
+          alignment: justify
+          chips:
+            - type: template
               icon: mdi:lightning-bolt
-            - entity: sensor.dishwasher_common_option_waterforecast
-              name: Agua prevista
+              icon_color: yellow
+              content: "{{ states('sensor.dishwasher_common_option_energyforecast') }}%"
+            - type: template
               icon: mdi:water
+              icon_color: blue
+              content: "{{ states('sensor.dishwasher_common_option_waterforecast') }}%"
+            - type: template
+              icon: mdi:clock-start
+              content: "{{ states('time.dishwasher_common_option_startinrelative') }}"
 
         - type: horizontal-stack
           cards:

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -11,15 +11,15 @@ browser_mod:
       type: vertical-stack
       cards:
         - type: custom:mushroom-template-card
-          primary: "{{ states('sensor.dishwasher_status_operationstate') }}"
+          primary: "{{ states('sensor.dishwasher_common_status_operationstate') }}"
           secondary: >
-            {% set prog = states('sensor.dishwasher_selected_program') %}
+            {% set prog = states('sensor.dishwasher_elected_program') %}
             {% set t    = states('sensor.dishwasher_common_option_remainingprogramtime') %}
             {% if prog not in ['unavailable','unknown',''] %}{{ prog }}{% endif %}
             {%- if t not in ['unavailable','unknown','0',''] %} · termina {{ as_timestamp(t) | timestamp_custom('%H:%M') }}{% endif %}
           icon: mdi:dishwasher
           icon_color: >
-            {% set s = states('sensor.dishwasher_status_operationstate') %}
+            {% set s = states('sensor.dishwasher_common_status_operationstate') %}
             {% if   'Run'            in s %}blue
             {% elif 'Finished'       in s %}green
             {% elif 'Pause'          in s %}orange
@@ -33,19 +33,19 @@ browser_mod:
           chips:
             - type: template
               icon: >
-                {% if 'Run' in states('sensor.dishwasher_status_operationstate') %}
+                {% if 'Run' in states('sensor.dishwasher_common_status_operationstate') %}
                   mdi:pause-circle-outline
                 {% else %}
                   mdi:play-circle-outline
                 {% endif %}
               icon_color: >
-                {% if 'Run' in states('sensor.dishwasher_status_operationstate') %}
+                {% if 'Run' in states('sensor.dishwasher_common_status_operationstate') %}
                   orange
                 {% else %}
                   green
                 {% endif %}
               content: >
-                {% if 'Run' in states('sensor.dishwasher_status_operationstate') %}
+                {% if 'Run' in states('sensor.dishwasher_common_status_operationstate') %}
                   Pause
                 {% else %}
                   Start

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -33,28 +33,34 @@ browser_mod:
           tap_action:
             action: none
 
-        # ── Arrancar / Parar ────────────────────────────────────────────────
+        # ── Arrancar / Pausar ───────────────────────────────────────────────
         - type: custom:mushroom-chips-card
           alignment: center
           chips:
             - type: template
-              icon: mdi:play-circle-outline
-              icon_color: green
-              content: Arrancar
+              icon: >
+                {% if 'Run' in states('sensor.dishwasher_status_operationstate') %}
+                  mdi:pause-circle-outline
+                {% else %}
+                  mdi:play-circle-outline
+                {% endif %}
+              icon_color: >
+                {% if 'Run' in states('sensor.dishwasher_status_operationstate') %}
+                  orange
+                {% else %}
+                  green
+                {% endif %}
+              content: >
+                {% if 'Run' in states('sensor.dishwasher_status_operationstate') %}
+                  Pause
+                {% else %}
+                  Start
+                {% endif %}
               tap_action:
                 action: call-service
                 service: button.press
                 target:
                   entity_id: button.dishwasher_start_pause
-            - type: template
-              icon: mdi:stop-circle-outline
-              icon_color: red
-              content: Parar
-              tap_action:
-                action: call-service
-                service: button.press
-                target:
-                  entity_id: button.dishwasher_stop
 
         # ── Selección de programa e inicio retrasado ────────────────────────
         - type: entities

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -1,9 +1,8 @@
-# Dishwasher (Lavavajillas) - Popup panel
+# Dishwasher (Lavavajillas) - Popup panel con Mushroom Cards
 # Triggered via browser_mod when tapping the lavavajillas entity in the main view.
 #
-# ⚠️  Entity IDs: rename the device in HA first, then replace the prefix
-#     "lavavajillas" with the alias que hayas puesto. Los marcados "# ?" hay
-#     que verificarlos en Developer Tools → States.
+# ⚠️  Los marcados "# ?" hay que verificarlos en Developer Tools → States
+#     tras renombrar el dispositivo.
 
 action: fire-dom-event
 browser_mod:
@@ -18,24 +17,57 @@ browser_mod:
       type: vertical-stack
       cards:
 
-        # ── Estado principal ────────────────────────────────────────────────
-        - type: tile
-          entity: sensor.lavavajillas_status_operationstate
+        # ── Estado principal con color y texto dinámico ─────────────────────
+        - type: custom:mushroom-template-card
+          primary: >
+            {% set s = states('sensor.lavavajillas_status_operationstate') %}
+            {% if   'Run'            in s %}En marcha
+            {% elif 'Finished'       in s %}¡Terminado! Puedes vaciarlo
+            {% elif 'Pause'          in s %}En pausa
+            {% elif 'ActionRequired' in s %}Acción requerida
+            {% elif 'Ready'          in s %}Listo
+            {% else %}{{ s }}{% endif %}
+          secondary: >
+            {% set prog = states('sensor.lavavajillas_program_selected') %}
+            {% set t    = states('sensor.lavavajillas_bsh_common_option_remainingprogramtime') %}
+            {% if prog not in ['unavailable','unknown',''] %}{{ prog }}{% endif %}
+            {%- if t not in ['unavailable','unknown','0',''] %} · termina {{ as_timestamp(t) | timestamp_custom('%H:%M') }}{% endif %}
           icon: mdi:dishwasher
+          icon_color: >
+            {% set s = states('sensor.lavavajillas_status_operationstate') %}
+            {% if   'Run'            in s %}blue
+            {% elif 'Finished'       in s %}green
+            {% elif 'Pause'          in s %}orange
+            {% elif 'ActionRequired' in s %}red
+            {% else %}disabled{% endif %}
+          tap_action:
+            action: none
 
-        # ── Info del ciclo ──────────────────────────────────────────────────
-        - type: entities
-          entities:
-            - entity: sensor.lavavajillas_bsh_common_option_remainingprogramtime
-              name: Tiempo restante
-              icon: mdi:timer-sand
-            - entity: sensor.lavavajillas_program_selected  # ?
-              name: Programa en curso
-              icon: mdi:format-list-bulleted
+        # ── Arrancar / Parar ────────────────────────────────────────────────
+        - type: custom:mushroom-chips-card
+          alignment: center
+          chips:
+            - type: template
+              icon: mdi:play-circle-outline
+              icon_color: green
+              content: Arrancar
+              tap_action:
+                action: call-service
+                service: button.press
+                target:
+                  entity_id: button.lavavajillas_start  # ?
+            - type: template
+              icon: mdi:stop-circle-outline
+              icon_color: red
+              content: Parar
+              tap_action:
+                action: call-service
+                service: button.press
+                target:
+                  entity_id: button.lavavajillas_stop  # ?
 
-        # ── Arrancar ────────────────────────────────────────────────────────
+        # ── Selección de programa e inicio retrasado ────────────────────────
         - type: entities
-          title: Arrancar
           entities:
             - entity: select.lavavajillas_programs  # ?
               name: Programa
@@ -44,43 +76,31 @@ browser_mod:
               name: Inicio retrasado
               icon: mdi:clock-start
 
+        # ── Opciones ────────────────────────────────────────────────────────
         - type: horizontal-stack
           cards:
-            - type: button
-              name: Arrancar
-              icon: mdi:play-circle-outline
-              tap_action:
-                action: call-service
-                service: button.press
-                target:
-                  entity_id: button.lavavajillas_start  # ?
-            - type: button
-              name: Parar
-              icon: mdi:stop-circle-outline
-              tap_action:
-                action: call-service
-                service: button.press
-                target:
-                  entity_id: button.lavavajillas_stop  # ?
-
-        # ── Opciones ────────────────────────────────────────────────────────
-        - type: entities
-          title: Opciones
-          entities:
-            - entity: switch.lavavajillas_setting_halfload  # ?  (media carga)
+            - type: custom:mushroom-entity-card
+              entity: switch.lavavajillas_setting_halfload  # ?
               name: Media carga
               icon: mdi:fraction-one-half
-            - entity: switch.lavavajillas_setting_variospeedplus  # ?
-              name: varioSpeed Plus
+              tap_action:
+                action: toggle
+            - type: custom:mushroom-entity-card
+              entity: switch.lavavajillas_setting_variospeedplus  # ?
+              name: varioSpeed+
               icon: mdi:speedometer
+              tap_action:
+                action: toggle
 
-        # ── Consumo previsto del ciclo ──────────────────────────────────────
-        - type: entities
-          title: Consumo del ciclo
-          entities:
-            - entity: sensor.lavavajillas_bsh_common_option_energyforecast
-              name: Energía prevista
+        # ── Consumo previsto ────────────────────────────────────────────────
+        - type: custom:mushroom-chips-card
+          alignment: justify
+          chips:
+            - type: template
               icon: mdi:lightning-bolt
-            - entity: sensor.lavavajillas_bsh_common_option_waterforecast
-              name: Agua prevista
+              icon_color: yellow
+              content: "Energía {{ states('sensor.lavavajillas_bsh_common_option_energyforecast') }}%"
+            - type: template
               icon: mdi:water
+              icon_color: blue
+              content: "Agua {{ states('sensor.lavavajillas_bsh_common_option_waterforecast') }}%"

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -13,7 +13,7 @@ browser_mod:
         - type: custom:mushroom-template-card
           primary: "{{ states('sensor.dishwasher_common_status_operationstate') }}"
           secondary: >
-            {% set prog = states('sensor.dishwasher_elected_program') %}
+            {% set prog = states('sensor.dishwasher_selected_program') %}
             {% set t    = states('sensor.dishwasher_common_option_remainingprogramtime') %}
             {% if prog not in ['unavailable','unknown',''] %}{{ prog }}{% endif %}
             {%- if t not in ['unavailable','unknown','0',''] %} · termina {{ as_timestamp(t) | timestamp_custom('%H:%M') }}{% endif %}

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -11,11 +11,8 @@ browser_mod:
       type: vertical-stack
       cards:
         - type: custom:mushroom-template-card
-          primary: >
-            {{ states('sensor.dishwasher_common_status_operationstate').split('.')[-1] }}
-          secondary: >
-            {% set prog = states('sensor.dishwasher_selected_program') %}
-            {% if prog not in ['unavailable','unknown',''] %}{{ prog.split('.')[-1] }}{% endif %}
+          primary: "{{ states('sensor.dishwasher_common_status_operationstate') }}"
+          secondary: "{{ states('sensor.dishwasher_selected_program') }}"
           icon: mdi:dishwasher
           icon_color: >
             {% set s = states('sensor.dishwasher_common_status_operationstate') %}

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -11,12 +11,11 @@ browser_mod:
       type: vertical-stack
       cards:
         - type: custom:mushroom-template-card
-          primary: "{{ states('sensor.dishwasher_common_status_operationstate') }}"
+          primary: >
+            {{ states('sensor.dishwasher_common_status_operationstate').split('.')[-1] }}
           secondary: >
             {% set prog = states('sensor.dishwasher_selected_program') %}
-            {% set t    = states('sensor.dishwasher_common_option_remainingprogramtime') %}
-            {% if prog not in ['unavailable','unknown',''] %}{{ prog }}{% endif %}
-            {%- if t not in ['unavailable','unknown','0',''] %} · termina {{ as_timestamp(t) | timestamp_custom('%H:%M') }}{% endif %}
+            {% if prog not in ['unavailable','unknown',''] %}{{ prog.split('.')[-1] }}{% endif %}
           icon: mdi:dishwasher
           icon_color: >
             {% set s = states('sensor.dishwasher_common_status_operationstate') %}
@@ -64,6 +63,16 @@ browser_mod:
             - entity: time.dishwasher_common_option_startinrelative
               name: Inicio retrasado
               icon: mdi:clock-start
+            - entity: sensor.dishwasher_common_option_remainingprogramtime
+              name: Termina a las
+              icon: mdi:clock-end
+              format: time
+            - entity: sensor.dishwasher_common_option_energyforecast
+              name: Energía prevista
+              icon: mdi:lightning-bolt
+            - entity: sensor.dishwasher_common_option_waterforecast
+              name: Agua prevista
+              icon: mdi:water
 
         - type: horizontal-stack
           cards:
@@ -79,15 +88,3 @@ browser_mod:
               icon: mdi:speedometer
               tap_action:
                 action: toggle
-
-        - type: custom:mushroom-chips-card
-          alignment: justify
-          chips:
-            - type: template
-              icon: mdi:lightning-bolt
-              icon_color: yellow
-              content: "Energía {{ states('sensor.dishwasher_common_option_energyforecast') }}%"
-            - type: template
-              icon: mdi:water
-              icon_color: blue
-              content: "Agua {{ states('sensor.dishwasher_common_option_waterforecast') }}%"

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -1,6 +1,3 @@
-# Dishwasher (Lavavajillas) - Popup panel con Mushroom Cards
-# Triggered via browser_mod when tapping the lavavajillas entity in the main view.
-
 action: fire-dom-event
 browser_mod:
   service: browser_mod.popup
@@ -13,8 +10,6 @@ browser_mod:
     content:
       type: vertical-stack
       cards:
-
-        # ── Estado principal con color y texto dinámico ─────────────────────
         - type: custom:mushroom-template-card
           primary: "{{ states('sensor.dishwasher_status_operationstate') }}"
           secondary: >
@@ -33,7 +28,6 @@ browser_mod:
           tap_action:
             action: none
 
-        # ── Arrancar / Pausar ───────────────────────────────────────────────
         - type: custom:mushroom-chips-card
           alignment: center
           chips:
@@ -62,7 +56,6 @@ browser_mod:
                 target:
                   entity_id: button.dishwasher_start_pause
 
-        # ── Selección de programa e inicio retrasado ────────────────────────
         - type: entities
           entities:
             - entity: select.dishwasher_programs
@@ -72,7 +65,6 @@ browser_mod:
               name: Inicio retrasado
               icon: mdi:clock-start
 
-        # ── Opciones ────────────────────────────────────────────────────────
         - type: horizontal-stack
           cards:
             - type: custom:mushroom-entity-card
@@ -88,7 +80,6 @@ browser_mod:
               tap_action:
                 action: toggle
 
-        # ── Consumo previsto ────────────────────────────────────────────────
         - type: custom:mushroom-chips-card
           alignment: justify
           chips:

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -60,10 +60,9 @@ browser_mod:
             - entity: select.dishwasher_programs
               name: Programa
               icon: mdi:format-list-bulleted
-            - entity: sensor.dishwasher_common_option_remainingprogramtime
-              name: Termina a las
-              icon: mdi:clock-end
-              format: time
+            - entity: time.dishwasher_common_option_startinrelative
+              name: Inicio retrasado
+              icon: mdi:clock-start
 
         - type: custom:mushroom-chips-card
           alignment: justify
@@ -77,8 +76,8 @@ browser_mod:
               icon_color: blue
               content: "{{ states('sensor.dishwasher_common_option_waterforecast') }}%"
             - type: template
-              icon: mdi:clock-start
-              content: "{{ states('time.dishwasher_common_option_startinrelative') }}"
+              icon: mdi:clock-end
+              content: "{{ as_timestamp(states('sensor.dishwasher_common_option_remainingprogramtime')) | timestamp_custom('%H:%M') }}"
 
         - type: horizontal-stack
           cards:

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -1,0 +1,86 @@
+# Dishwasher (Lavavajillas) - Popup panel
+# Triggered via browser_mod when tapping the lavavajillas entity in the main view.
+#
+# ⚠️  Entity IDs: rename the device in HA first, then replace the prefix
+#     "lavavajillas" with the alias que hayas puesto. Los marcados "# ?" hay
+#     que verificarlos en Developer Tools → States.
+
+action: fire-dom-event
+browser_mod:
+  service: browser_mod.popup
+  style:
+    border-radius: 0px
+    '--ha-card-border-radius': 0px
+  data:
+    title: Lavavajillas
+    dismissable: true
+    content:
+      type: vertical-stack
+      cards:
+
+        # ── Estado principal ────────────────────────────────────────────────
+        - type: tile
+          entity: sensor.lavavajillas_status_operationstate
+          icon: mdi:dishwasher
+
+        # ── Info del ciclo ──────────────────────────────────────────────────
+        - type: entities
+          entities:
+            - entity: sensor.lavavajillas_bsh_common_option_remainingprogramtime
+              name: Tiempo restante
+              icon: mdi:timer-sand
+            - entity: sensor.lavavajillas_program_selected  # ?
+              name: Programa en curso
+              icon: mdi:format-list-bulleted
+
+        # ── Arrancar ────────────────────────────────────────────────────────
+        - type: entities
+          title: Arrancar
+          entities:
+            - entity: select.lavavajillas_programs  # ?
+              name: Programa
+              icon: mdi:format-list-bulleted
+            - entity: select.lavavajillas_bsh_common_option_startinrelative
+              name: Inicio retrasado
+              icon: mdi:clock-start
+
+        - type: horizontal-stack
+          cards:
+            - type: button
+              name: Arrancar
+              icon: mdi:play-circle-outline
+              tap_action:
+                action: call-service
+                service: button.press
+                target:
+                  entity_id: button.lavavajillas_start  # ?
+            - type: button
+              name: Parar
+              icon: mdi:stop-circle-outline
+              tap_action:
+                action: call-service
+                service: button.press
+                target:
+                  entity_id: button.lavavajillas_stop  # ?
+
+        # ── Opciones ────────────────────────────────────────────────────────
+        - type: entities
+          title: Opciones
+          entities:
+            - entity: switch.lavavajillas_setting_halfload  # ?  (media carga)
+              name: Media carga
+              icon: mdi:fraction-one-half
+            - entity: switch.lavavajillas_setting_variospeedplus  # ?
+              name: varioSpeed Plus
+              icon: mdi:speedometer
+
+        # ── Consumo previsto del ciclo ──────────────────────────────────────
+        - type: entities
+          title: Consumo del ciclo
+          entities:
+            - entity: sensor.lavavajillas_bsh_common_option_energyforecast
+              name: Energía prevista
+              icon: mdi:lightning-bolt
+            - entity: sensor.lavavajillas_bsh_common_option_waterforecast
+              name: Agua prevista
+              icon: mdi:water

--- a/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/dishwasher-card.yaml
@@ -1,8 +1,5 @@
 # Dishwasher (Lavavajillas) - Popup panel con Mushroom Cards
 # Triggered via browser_mod when tapping the lavavajillas entity in the main view.
-#
-# ⚠️  Los marcados "# ?" hay que verificarlos en Developer Tools → States
-#     tras renombrar el dispositivo.
 
 action: fire-dom-event
 browser_mod:
@@ -19,15 +16,15 @@ browser_mod:
 
         # ── Estado principal con color y texto dinámico ─────────────────────
         - type: custom:mushroom-template-card
-          primary: "{{ states('sensor.lavavajillas_status_operationstate') }}"
+          primary: "{{ states('sensor.dishwasher_status_operationstate') }}"
           secondary: >
-            {% set prog = states('sensor.lavavajillas_program_selected') %}
-            {% set t    = states('sensor.lavavajillas_bsh_common_option_remainingprogramtime') %}
+            {% set prog = states('sensor.dishwasher_selected_program') %}
+            {% set t    = states('sensor.dishwasher_common_option_remainingprogramtime') %}
             {% if prog not in ['unavailable','unknown',''] %}{{ prog }}{% endif %}
             {%- if t not in ['unavailable','unknown','0',''] %} · termina {{ as_timestamp(t) | timestamp_custom('%H:%M') }}{% endif %}
           icon: mdi:dishwasher
           icon_color: >
-            {% set s = states('sensor.lavavajillas_status_operationstate') %}
+            {% set s = states('sensor.dishwasher_status_operationstate') %}
             {% if   'Run'            in s %}blue
             {% elif 'Finished'       in s %}green
             {% elif 'Pause'          in s %}orange
@@ -48,7 +45,7 @@ browser_mod:
                 action: call-service
                 service: button.press
                 target:
-                  entity_id: button.lavavajillas_start  # ?
+                  entity_id: button.dishwasher_start_pause
             - type: template
               icon: mdi:stop-circle-outline
               icon_color: red
@@ -57,15 +54,15 @@ browser_mod:
                 action: call-service
                 service: button.press
                 target:
-                  entity_id: button.lavavajillas_stop  # ?
+                  entity_id: button.dishwasher_stop
 
         # ── Selección de programa e inicio retrasado ────────────────────────
         - type: entities
           entities:
-            - entity: select.lavavajillas_programs  # ?
+            - entity: select.dishwasher_programs
               name: Programa
               icon: mdi:format-list-bulleted
-            - entity: select.lavavajillas_bsh_common_option_startinrelative
+            - entity: time.dishwasher_common_option_startinrelative
               name: Inicio retrasado
               icon: mdi:clock-start
 
@@ -73,13 +70,13 @@ browser_mod:
         - type: horizontal-stack
           cards:
             - type: custom:mushroom-entity-card
-              entity: switch.lavavajillas_setting_halfload  # ?
+              entity: switch.dishwasher_dishcare_option_halfload
               name: Media carga
               icon: mdi:fraction-one-half
               tap_action:
                 action: toggle
             - type: custom:mushroom-entity-card
-              entity: switch.lavavajillas_setting_variospeedplus  # ?
+              entity: switch.dishwasher_dishcare_option_variospeedplus
               name: varioSpeed+
               icon: mdi:speedometer
               tap_action:
@@ -92,8 +89,8 @@ browser_mod:
             - type: template
               icon: mdi:lightning-bolt
               icon_color: yellow
-              content: "Energía {{ states('sensor.lavavajillas_bsh_common_option_energyforecast') }}%"
+              content: "Energía {{ states('sensor.dishwasher_common_option_energyforecast') }}%"
             - type: template
               icon: mdi:water
               icon_color: blue
-              content: "Agua {{ states('sensor.lavavajillas_bsh_common_option_waterforecast') }}%"
+              content: "Agua {{ states('sensor.dishwasher_common_option_waterforecast') }}%"


### PR DESCRIPTION
## Summary
This PR integrates the Mushroom custom card library into the Home Assistant setup and refactors the UI to use Mushroom template cards for improved visual consistency and functionality. A new interactive dishwasher control card is added with detailed status and operation controls.

## Key Changes

- **Mushroom Cards Integration**: Added Mushroom card library (v5.1.1) to the Docker build process and Home Assistant configuration
  - Updated Dockerfile to download and include mushroom.js
  - Added environment variables for Mushroom card versioning and path
  - Registered Mushroom module in lovelace configuration

- **Enhanced People Location Cards**: Replaced basic tile cards with Mushroom template cards for Manolo and Mónica status displays
  - Added dynamic icons based on presence state (Home, Away, Just Arrived, etc.)
  - Implemented color-coded status indicators (green for home, red for away, etc.)
  - Improved visual hierarchy with primary/secondary text layout

- **New Dishwasher Control Card**: Created comprehensive dishwasher management interface (`dishwasher-card.yaml`)
  - Status display with operation state and remaining time
  - Play/pause controls for start/pause operations
  - Program selection and delayed start scheduling
  - Toggle switches for half-load and varioSpeed+ options
  - Energy and water consumption forecasts
  - Integrated into home map view and turned-on entities list

- **Entity ID Standardization**: Updated dishwasher entity references from `sensor.lavavajillas_status_operationstate` to `sensor.dishwasher_status_operationstate` for consistency

## Implementation Details

- Dishwasher card uses Jinja2 templating for dynamic icon colors and content based on operation state
- Browser mod popup integration for modal dishwasher control interface
- Mushroom chips and entity cards provide compact, interactive controls
- All custom cards properly versioned and managed through environment variables for easy updates

https://claude.ai/code/session_01524jK8TArAf1PZtmSU1ZT3