### PR TITLE
Remove debug door opened Telegram notification

### DIFF
--- a/home_automation/home_assistant/config/packages/security/automation.yaml
+++ b/home_automation/home_assistant/config/packages/security/automation.yaml
@@ -87,21 +87,6 @@
               message: "Unbanned and restarting HomeAssistant"
       - service: homeassistant.restart
 
-  - alias: AUT-Notify Entrance Door Opened
-    id: AUT-Notify_Entrance_Door_Opened
-    initial_state: 'on'
-    triggers:
-      - platform: state
-        entity_id: binary_sensor.entrance_door_sensor_opened
-        to: 'on'
-    actions:
-      - service: script.telegram_notify
-        data:
-          target_person: manolo
-          title: '[Debug] *Door Opened*'
-          message: 'The entrance door has been opened.'
-          disable_notification: true
-
   - alias: AUT-Notify Entrance Door Opened Extended Away
     id: AUT-Notify_Entrance_Door_Opened_Extended_Away
     initial_state: 'on'


### PR DESCRIPTION
## Summary

- Elimina la automatización `AUT-Notify_Entrance_Door_Opened` que enviaba un mensaje `[Debug] *Door Opened*` por Telegram cada vez que se abría la puerta de entrada.
- El resto de automatizaciones relacionadas con la puerta (alerta en Extended Away, puerta abierta más de 3 minutos, grabación de cámara) permanecen intactas.

https://claude.ai/code/session_01KZmJsAVcFHAJYjgwdm465Y