### PR TITLE
Filter door camera notifications by away state

### DIFF
--- a/home_automation/home_assistant/config/packages/security/automation.yaml
+++ b/home_automation/home_assistant/config/packages/security/automation.yaml
@@ -230,7 +230,7 @@
     actions:
       - alias: "Define target person"
         variables:
-          notification_target_person: "{{ 'auto' if states('input_boolean.centinel_mode') == 'on' else 'manolo' }}"
+          notification_target_person: "{{ 'auto' if states('input_boolean.centinel_mode') == 'on' else ('manolo' if states('sensor.home_occupancy_status') in ['Away', 'Extended Away', 'Just Arrived'] else 'none') }}"
 
       # Immediate notification (does not block the camera)
       - service: script.telegram_notify


### PR DESCRIPTION
## Summary
- Only notify Manolo of door camera recordings when the house is in Away, Extended Away, or Just Arrived state
- When the house is Home or Just Left, `target_person` is set to `'none'`, which resolves to an empty target list in `telegram_notify` — no notification is sent
- Recordings still execute (condition block remains commented out for dev), but no Telegram spam when the house is occupied

## Changed file
- `home_automation/home_assistant/config/packages/security/automation.yaml` — line 233

## Test plan
- [ ] Verify no notifications are received when the house is in Home/Just Left state and the door opens
- [ ] Verify Manolo receives notifications when the house is in Away/Extended Away
- [ ] Verify centinel_mode ON still sends to 'auto' as before

https://claude.ai/code/session_01HrttRJ7Ks3JiYNs1Psrcv9