### PR TITLE
Extend camera pre-event buffer from 5s to 13s

### DIFF
--- a/home_automation/home_assistant/config/packages/security/automation.yaml
+++ b/home_automation/home_assistant/config/packages/security/automation.yaml
@@ -215,7 +215,7 @@
       # notification_target_person: auto
 
       ## All the start/ends times are relative to the trigger time
-      record1_start: -5
+      record1_start: -13
       record1_end: 4
       record1_processing_time: 3
       record1_filename: "/tmp/homeassistant/camera_recordings/entrance_{{ trigger_time }}_01.mp4"
@@ -223,7 +223,7 @@
       record2_end: 10
       record2_processing_time: 3
       record2_filename: "/tmp/homeassistant/camera_recordings/entrance_{{ trigger_time }}_02.mp4"
-      record3_start: -5
+      record3_start: -13
       record3_end: 60
       record3_processing_time: 7
       record3_filename: "/tmp/homeassistant/camera_recordings/entrance_{{ trigger_time }}_03.mp4"


### PR DESCRIPTION
## Summary

- Aumenta el tiempo de pre-grabación de la cámara de entrada de 5s a **13s** antes del evento (`record1_start` y `record3_start`)
- Mueve la notificación Telegram inicial a un bloque **paralelo** con `camera.record` para que no consuma buffer antes de iniciar la grabación

## Diagnóstico del problema

La fórmula de `lookback` en `camera.record` está diseñada para ser independiente del tiempo de ejecución:

```
lookback = trigger_time_unix + record_start - as_timestamp(now())
start    = call_time + lookback = T + record_start  ✓
```

El problema era que `script.telegram_notify` (llamado secuencialmente antes de `camera.record`) es **bloqueante**: espera respuesta de los servidores de Telegram (~2-5s). Ese retraso consumía el ring buffer antes de que se llamara a `camera.record`.

Con `record_start = -13` y un retraso de 3-5s, el buffer necesario era ~16-18s, justo en el límite del ring buffer por defecto (~18s = 3 segmentos × 6s), fallando de forma intermitente.

**Nota:** `stream: segment_duration` fue investigado y descartado — solo afecta la latencia del streaming en vivo, no el tamaño del ring buffer de `camera.record`.

## Fix

Mover la notificación inicial a paralelo reduce δ a ~0s, de modo que el lookback necesario es exactamente 13s, bien por debajo del buffer por defecto de 18s.

```
Antes:  telegram_notify (bloquea 2-5s) → camera.record
Ahora:  telegram_notify ─┐ (simultáneo, δ≈0)
        camera.record    ┘
```

## Test plan

- [ ] Verificar que el clip inicial (record1) empieza ~13s antes del trigger
- [ ] Verificar que el clip largo (record3) también empieza ~13s antes del trigger
- [ ] Confirmar que la notificación de alerta inicial llega por Telegram antes o al mismo tiempo que antes
- [ ] Confirmar que los tres vídeos llegan correctamente por Telegram