### PR TITLE
Fix inverted lookback formula in camera.record

### DIFF
--- a/home_automation/home_assistant/config/packages/security/automation.yaml
+++ b/home_automation/home_assistant/config/packages/security/automation.yaml
@@ -214,7 +214,9 @@
       trigger_time_unix: "{{ as_timestamp(now()) }}"
       # notification_target_person: auto
 
-      ## All the start/ends times are relative to the trigger time
+      ## All start/end times are relative to the trigger time.
+      ## lookback = now() - T - record_start  (positive value → HA looks back in the ring buffer)
+      ## duration = T + record_end - now()    (positive value → HA records forward from now)
       record1_start: -13
       record1_end: 4
       record1_processing_time: 3
@@ -254,7 +256,7 @@
             target:
               entity_id: camera.entrance_camera
             data:
-              lookback: '{{ trigger_time_unix + record1_start - as_timestamp(now()) | round(0, "floor") }}'
+              lookback: '{{ [as_timestamp(now()) - trigger_time_unix - record1_start, 0] | max | round(0, "ceil") }}'
               duration: '{{ trigger_time_unix + record1_end - as_timestamp(now()) | round(0, "ceil") }}'
               filename: '{{ record1_filename }}'
           - parallel:
@@ -274,7 +276,7 @@
                 target:
                   entity_id: camera.entrance_camera
                 data:
-                  lookback: '{{ trigger_time_unix + record2_start - as_timestamp(now()) | round(0, "floor") }}'
+                  lookback: '{{ [as_timestamp(now()) - trigger_time_unix - record2_start, 0] | max | round(0, "ceil") }}'
                   duration: '{{ trigger_time_unix + record2_end - as_timestamp(now()) | round(0, "ceil") }}'
                   filename: '{{ record2_filename }}'
               - parallel:
@@ -294,7 +296,7 @@
                     target:
                       entity_id: camera.entrance_camera
                     data:
-                      lookback: '{{ trigger_time_unix + record3_start - as_timestamp(now()) | round(0, "floor") }}'
+                      lookback: '{{ [as_timestamp(now()) - trigger_time_unix - record3_start, 0] | max | round(0, "ceil") }}'
                       duration: '{{ trigger_time_unix + record3_end - as_timestamp(now()) | round(0, "ceil") }}'
                       filename: '{{ record3_filename }}'
                   - delay:


### PR DESCRIPTION
## Summary

Fixes a sign-inverted `lookback` formula in the Centinel Mode camera recording automation that was causing recordings to start at the wrong time (after the trigger instead of before it).

## Root cause

The original formula produced **negative** lookback values:
```
lookback = trigger_time_unix + record_start - now()
         = T + (-13) - T = -13  ← negative
```

HA's `camera.record` source (`stream/__init__.py`):
```python
num_segments = min(int(lookback / hls.target_duration) + 1, MAX_SEGMENTS)
recorder.prepend(list(hls.get_segments())[-num_segments - 1 : -1])
```

With negative lookback, `num_segments` becomes negative, and the Python slice selects an **unpredictable portion** of the ring buffer — with a **larger negative value selecting fewer segments**, which is the opposite of the intended behaviour:

| lookback | target_duration | num_segments | slice | result |
|---|---|---|---|---|
| `-6` (record_start=-5) | 2s | `int(-3)+1 = -2` | `[1:-1]` | 3 segments ≈ 6s → starts ~T-5 ✓ (worked by accident) |
| `-14` (record_start=-13) | 2s | `int(-7)+1 = -6` | `[5:-1]` | **0 segments** → starts at T+now → **+1s to +6s** ✗ |

## Fix

Negate the formula so `lookback` is always positive, and clamp to 0 for recordings that start in the future (record2):

```yaml
# Before (broken — negative):
lookback: '{{ trigger_time_unix + record_start - as_timestamp(now()) | round(0, "floor") }}'

# After (correct — positive):
lookback: '{{ [as_timestamp(now()) - trigger_time_unix - record_start, 0] | max | round(0, "ceil") }}'
```

Results with `MAX_SEGMENTS=5`, `target_duration≈6s` (30s ring buffer):
- **record1** called at T: `lookback = 13` → 3 segments × 6s → starts at T-18 ✓
- **record2** called at T+4: `lookback = 0` → no rewind, starts from T+4 ✓
- **record3** called at T+10: `lookback = 23` → 5 segments × 6s → starts at T-20 ✓

## Test plan

- [ ] Verify record1 starts ~13s before the trigger event
- [ ] Verify record3 also starts ~13s before the trigger event
- [ ] Verify record2 starts right after the trigger (~T+4s)
- [ ] Confirm all three clips are delivered correctly via Telegram