### PR TITLE
Update Home Assistant 2026.2.3 → 2026.5.4 (+ compatible custom components)

### DIFF
--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/home-assistant:2026.2.3
+FROM ghcr.io/home-assistant/home-assistant:2026.5.4
 
 ##### Pending tasks
 # - Redo all scripts/automations with the news if/else/then, for each, continue on error, parallelize
@@ -15,7 +15,7 @@ ENV \
     #   # renovatebot: datasource=github-releases depName=custom-components/ble_monitor
     # CUSTOM_COMPONENT_BLE_MONITOR_VERSION=9.2.0 \
       # renovatebot: datasource=github-releases depName=thomasloven/hass-browser_mod versioning=semver
-    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v2.7.4 \
+    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v2.13.5 \
       # renovatebot: datasource=github-releases depName=leikoilja/ha-google-home
     CUSTOM_COMPONENT_GOOGLE_HOME_VERSION=v1.13.3 \
       # renovatebot: datasource=github-releases depName=PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor
@@ -27,13 +27,13 @@ ENV \
       # renovatebot: datasource=github-releases depName=uvejota/homeassistant-edata
     CUSTOM_COMPONENT_EDATA_VERSION=2025.11.3 \
       # renovatebot: datasource=github-releases depName=ekutner/home-connect-hass
-    CUSTOM_COMPONENT_HOME_CONNECT_VERSION=1.3.6 \
+    CUSTOM_COMPONENT_HOME_CONNECT_VERSION=1.4.1 \
       # renovatebot: datasource=github-releases depName=smartHomeHub/SmartIR
     CUSTOM_COMPONENT_SMARTIR_VERSION=1.18.1 \
       # renovatebot: datasource=github-releases depName=eigger/hass-gicisky
     CUSTOM_COMPONENT_GICISKY_VERSION=2.1.0 \
       # renovatebot: datasource=github-releases depName=sca075/mqtt_vacuum_camera
-    CUSTOM_COMPONENT_MQTT_VACUUM_CAMERA_VERSION=2026.3.1 \
+    CUSTOM_COMPONENT_MQTT_VACUUM_CAMERA_VERSION=2026.5.0 \
       # renovatebot: datasource=github-releases depName=PiotrMachowski/lovelace-xiaomi-vacuum-map-card
     CUSTOM_CARD_XIAOMI_VACUUM_MAP_VERSION=v2.3.2 \
       # renovatebot: datasource=github-releases depName=Hypfer/lovelace-valetudo-map-card

--- a/home_automation/home_assistant/config/packages/ikea/automation.yaml
+++ b/home_automation/home_assistant/config/packages/ikea/automation.yaml
@@ -28,7 +28,7 @@
             scene_data:
               state: "on"
               brightness: 3
-              color_temp: 454
+              color_temp_kelvin: 2203
         tmp_trigger_nightstand_pulsation_and_scene__double_press_01: &trigger_nightstand_double_press_01
           type: remote_button_double_press
           subtype: button_1
@@ -37,7 +37,7 @@
             scene_data:
               state: "on"
               brightness: 180
-              color_temp: 285
+              color_temp_kelvin: 3509
         tmp_trigger_nightstand_pulsation_and_scene__long_press_01: &trigger_nightstand_long_press_01
           type: remote_button_long_press
           subtype: button_1
@@ -46,7 +46,7 @@
             scene_data:
               state: "on"
               brightness: 255
-              color_temp: 250
+              color_temp_kelvin: 4000
         tmp_trigger_nightstand_pulsation_and_scene__single_press_02: &trigger_nightstand_single_press_02
           type: remote_button_short_press
           subtype: button_2

--- a/home_automation/home_assistant/config/ui-views/utils/nightstand-lights.yaml
+++ b/home_automation/home_assistant/config/ui-views/utils/nightstand-lights.yaml
@@ -38,7 +38,7 @@ browser_mod:
                     light.bedroom_nightstand_lights:
                       state: "on"
                       brightness: 3
-                      color_temp: 454
+                      color_temp_kelvin: 2203
               icon_tap_action: *tap_action_min
             - name: Read
               type: tile
@@ -56,7 +56,7 @@ browser_mod:
                     light.bedroom_nightstand_lights:
                       state: "on"
                       brightness: 180
-                      color_temp: 285
+                      color_temp_kelvin: 3509
               icon_tap_action: *tap_action_read
             - name: Max
               type: tile
@@ -74,7 +74,7 @@ browser_mod:
                     light.bedroom_nightstand_lights:
                       state: "on"
                       brightness: 255
-                      color_temp: 250
+                      color_temp_kelvin: 4000
               icon_tap_action: *tap_action_max
         - type: horizontal-stack
           cards:


### PR DESCRIPTION
## Summary

Updates Home Assistant core from **2026.2.3 → 2026.5.4** (3 minor versions: 2026.3, 2026.4, 2026.5 — 2026.6 intentionally left out to stay within a 3-version jump), plus the custom components that need it for compatibility.

Followed the repo procedure in `home_automation/ai-instructions/HOME_ASSISTANT_UPDATE_PROCEDURE.md`.

## Changes

| Component | From | To | Reason |
|---|---|---|---|
| HA Core | 2026.2.3 | **2026.5.4** | Target update (latest 2026.5 patch) |
| browser_mod | v2.7.4 | **v2.13.5** | HA 2026.5 compatibility (`user_id` fix in 2.13.0). v3.0.0 left out — requires HA 2026.6 |
| mqtt_vacuum_camera | 2026.3.1 | **2026.5.0** | Align with HA + new floor-data services |
| home-connect-hass | 1.3.6 | **1.4.1** | Bugfixes + async lib 0.8.6 |
| gicisky | 2.1.0 | _unchanged_ | 3.0.0/4.0.0 carry their own breaking changes (write-service split, preview camera removal) |
| ESPHome | 2025.12.7 | _unchanged_ | Confirmed compatible with HA 2026.5 via native API |

## Breaking-changes analysis (2026.3 / 2026.4 / 2026.5)

**Affecting this config:**
- `color_temp` mireds → kelvin (2026.3): already migrated in commit 21f2056 (ikea + nightstand-lights).

**Verified clean in YAML:** MQTT `object_id`, person `entered_home`/`left_home` triggers, `is_home`/`is_not_home` conditions, Ring `ding` event, webhook `local_only`, `hassio.*` actions.

**UI integrations cross-checked** against the live integrations list — none of the removed/changed integrations are installed: BMW, Duke Energy, Tfiac, LANnouncer, pilight, pyLoad, Tado, Ring, Snapcast, StarLine, JVC Projector, Litter-Robot, Tuya, Roth Touchline, Motion Blinds, Gardena, BSB-Lan, Satel, LIFX, Z-Wave. (Uses Reolink not Ring; ZHA not Z-Wave JS.)

## Post-update notes (non-blocking)
- `woody` needs Docker ≥ 23.0.0 (images use `zstd` compression since 2026.3).
- `reset_trims` (mqtt_vacuum_camera) is deprecated → migrate to `camera_update_floor_data` before August 2026 if used.
- Pre-existing config errors (not caused by this update): AEMET, Broadlink, IPP, Reolink, esios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)