### PR TITLE
chore(esphome): update to 2026.7.2 and fix dashboard auth env vars

### DIFF
--- a/home_automation/docker-compose.yml
+++ b/home_automation/docker-compose.yml
@@ -45,10 +45,6 @@ services:
             # Use local time for logging timestamps
             - /etc/localtime:/etc/localtime:ro
         environment:
-            ## Since 2026.6.0 the image ships Device Builder as the dashboard, which
-            ## reads ESPHOME_USERNAME/ESPHOME_PASSWORD. The bare USERNAME/PASSWORD are
-            ## ignored, and this service is on host network, so the old names would
-            ## leave the dashboard unauthenticated on the LAN.
             - ESPHOME_USERNAME=${ESPHOME_DASHBOARD_USERNAME}
             - ESPHOME_PASSWORD=${ESPHOME_DASHBOARD_PASSWORD}
 

--- a/home_automation/docker-compose.yml
+++ b/home_automation/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             - "traefik.http.routers.home-assistant.tls.domains[0].sans=${EXTERNAL_WILDCARD_DOMAIN}"
 
     esphome:
-        image: esphome/esphome:2025.12.7
+        image: esphome/esphome:2026.7.2
         restart: unless-stopped
         # ports:
         #     - 0.0.0.0:6052:6052
@@ -45,8 +45,12 @@ services:
             # Use local time for logging timestamps
             - /etc/localtime:/etc/localtime:ro
         environment:
-            - USERNAME=${ESPHOME_DASHBOARD_USERNAME}
-            - PASSWORD=${ESPHOME_DASHBOARD_PASSWORD}
+            ## Since 2026.6.0 the image ships Device Builder as the dashboard, which
+            ## reads ESPHOME_USERNAME/ESPHOME_PASSWORD. The bare USERNAME/PASSWORD are
+            ## ignored, and this service is on host network, so the old names would
+            ## leave the dashboard unauthenticated on the LAN.
+            - ESPHOME_USERNAME=${ESPHOME_DASHBOARD_USERNAME}
+            - ESPHOME_PASSWORD=${ESPHOME_DASHBOARD_PASSWORD}
 
 
     postgres:


### PR DESCRIPTION
Bottom of a 4-PR stack. Merge in order; each PR targets the branch below it.

Bumps `esphome/esphome` from `2025.12.7` to `2026.7.2` (7 releases).

### Why the env var rename ships in the same PR

As of ESPHome **2026.6.0** the standard image bundles Device Builder as the dashboard, and it reads `ESPHOME_USERNAME` / `ESPHOME_PASSWORD`. The legacy bare `USERNAME` / `PASSWORD` are no longer honored — they were dropped because they collide with the OS-supplied `$USERNAME`.

This service runs with `network_mode: host`, so it binds `0.0.0.0:6052` on the LAN. Bumping the image without the rename would leave the dashboard **reachable with no auth gate**, so the two changes cannot be split across PRs. The outer `ESPHOME_DASHBOARD_*` names in `.env` are unchanged.

### Breaking changes reviewed: 2026.1 → 2026.7

Checked against `esphome/man-005--esphome.yml`, the only device config. It is unaffected:

- already on the `esp-idf` framework (2026.1 made it the default)
- no `api: password:` (removed in 2026.1)
- a single `ota:` entry (2026.5 forbids multiple)
- no i2s / lvgl / modbus / zigbee / web_server / image / cover components

The 2026.1 OTA MD5 → SHA256 switch requires coming from >= 2025.10; `2025.12.7` satisfies it.

### After merging

- 2026.7 switches the ESP32 default toolchain to native ESP-IDF → the device needs a **recompile and reflash**.
- HA 2026.6 switches Bluetooth proxy scanning to Auto → verify the `ble_presence` Tile sensors still report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)