### PR TITLE
chore(browser-mod): update v2.13.5 -> v3.1.0

### DIFF
--- a/home_automation/docker-compose.yml
+++ b/home_automation/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             - "traefik.http.routers.home-assistant.tls.domains[0].sans=${EXTERNAL_WILDCARD_DOMAIN}"
 
     esphome:
-        image: esphome/esphome:2025.12.7
+        image: esphome/esphome:2026.7.2
         restart: unless-stopped
         # ports:
         #     - 0.0.0.0:6052:6052
@@ -45,8 +45,12 @@ services:
             # Use local time for logging timestamps
             - /etc/localtime:/etc/localtime:ro
         environment:
-            - USERNAME=${ESPHOME_DASHBOARD_USERNAME}
-            - PASSWORD=${ESPHOME_DASHBOARD_PASSWORD}
+            ## Since 2026.6.0 the image ships Device Builder as the dashboard, which
+            ## reads ESPHOME_USERNAME/ESPHOME_PASSWORD. The bare USERNAME/PASSWORD are
+            ## ignored, and this service is on host network, so the old names would
+            ## leave the dashboard unauthenticated on the LAN.
+            - ESPHOME_USERNAME=${ESPHOME_DASHBOARD_USERNAME}
+            - ESPHOME_PASSWORD=${ESPHOME_DASHBOARD_PASSWORD}
 
 
     postgres:

--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/home-assistant:2026.5.4
+FROM ghcr.io/home-assistant/home-assistant:2026.7.4
 
 ##### Pending tasks
 # - Redo all scripts/automations with the news if/else/then, for each, continue on error, parallelize

--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -15,7 +15,7 @@ ENV \
     #   # renovatebot: datasource=github-releases depName=custom-components/ble_monitor
     # CUSTOM_COMPONENT_BLE_MONITOR_VERSION=9.2.0 \
       # renovatebot: datasource=github-releases depName=thomasloven/hass-browser_mod versioning=semver
-    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v2.13.5 \
+    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v3.1.0 \
       # renovatebot: datasource=github-releases depName=leikoilja/ha-google-home
     CUSTOM_COMPONENT_GOOGLE_HOME_VERSION=v1.13.3 \
       # renovatebot: datasource=github-releases depName=PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor


### PR DESCRIPTION
Stack layer 3 of 4. Targets #502 — merge that one first.

### Hard dependency on the core bump

`v3.0.0` requires Home Assistant **>= 2026.6.0**, and `v3.1.0` raises it to **>= 2026.7.0** (config panel top bar changes). This is why it sits above the core bump in the stack and cannot land on its own.

### The v3.0.0 breaking change is a UI relocation

The Browser Mod config panel moves into the integration settings, reached via the cog icon; "This Browser" stays as the Frontend Browser panel. **No YAML change is needed** — verified against the source rather than the release notes alone:

- `CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)` is byte-identical between `v2.13.5` and `v3.1.0`, so the bare `browser_mod:` key in `configuration.yaml` is still accepted.
- `popup`, `close_popup`, `set_popup_style`, `more_info` and the rest are all still declared in `services.yaml` at `v3.1.0`.
- The `fire-dom-event` mechanism is still implemented in `js/plugin/services.ts` and still documented.

That covers every use in this repo: `browser_mod.popup` via `fire-dom-event` in `ui-views/utils/` (tv-card, nightstand-lights, dishwasher-card, washing-machine-card). There is no `panel_custom` or `panels:` usage.

### Worth an eye after deploying

The popups here pass `style:` overrides (`border-radius`, `--ha-card-border-radius`). v3.0.0 migrated `ha-md-list-item` to `ha-row-item` and v3.1.0 changed popup theme handling. Those custom properties target the card rather than the list item so they should hold, but CSS overrides against internal DOM are the one thing that can't be confirmed without rendering. Give the four popups a quick look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)