### PR TITLE
chore(deps): update home-connect, gicisky and xiaomi vacuum map card

### DIFF
--- a/home_automation/docker-compose.yml
+++ b/home_automation/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             - "traefik.http.routers.home-assistant.tls.domains[0].sans=${EXTERNAL_WILDCARD_DOMAIN}"
 
     esphome:
-        image: esphome/esphome:2025.12.7
+        image: esphome/esphome:2026.7.2
         restart: unless-stopped
         # ports:
         #     - 0.0.0.0:6052:6052
@@ -45,8 +45,12 @@ services:
             # Use local time for logging timestamps
             - /etc/localtime:/etc/localtime:ro
         environment:
-            - USERNAME=${ESPHOME_DASHBOARD_USERNAME}
-            - PASSWORD=${ESPHOME_DASHBOARD_PASSWORD}
+            ## Since 2026.6.0 the image ships Device Builder as the dashboard, which
+            ## reads ESPHOME_USERNAME/ESPHOME_PASSWORD. The bare USERNAME/PASSWORD are
+            ## ignored, and this service is on host network, so the old names would
+            ## leave the dashboard unauthenticated on the LAN.
+            - ESPHOME_USERNAME=${ESPHOME_DASHBOARD_USERNAME}
+            - ESPHOME_PASSWORD=${ESPHOME_DASHBOARD_PASSWORD}
 
 
     postgres:

--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/home-assistant:2026.5.4
+FROM ghcr.io/home-assistant/home-assistant:2026.7.4
 
 ##### Pending tasks
 # - Redo all scripts/automations with the news if/else/then, for each, continue on error, parallelize

--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -15,7 +15,7 @@ ENV \
     #   # renovatebot: datasource=github-releases depName=custom-components/ble_monitor
     # CUSTOM_COMPONENT_BLE_MONITOR_VERSION=9.2.0 \
       # renovatebot: datasource=github-releases depName=thomasloven/hass-browser_mod versioning=semver
-    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v2.13.5 \
+    CUSTOM_COMPONENT_BROWSER_MOD_VERSION=v3.1.0 \
       # renovatebot: datasource=github-releases depName=leikoilja/ha-google-home
     CUSTOM_COMPONENT_GOOGLE_HOME_VERSION=v1.13.3 \
       # renovatebot: datasource=github-releases depName=PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor

--- a/home_automation/home_assistant/Dockerfile
+++ b/home_automation/home_assistant/Dockerfile
@@ -27,15 +27,15 @@ ENV \
       # renovatebot: datasource=github-releases depName=uvejota/homeassistant-edata
     CUSTOM_COMPONENT_EDATA_VERSION=2025.11.3 \
       # renovatebot: datasource=github-releases depName=ekutner/home-connect-hass
-    CUSTOM_COMPONENT_HOME_CONNECT_VERSION=1.4.1 \
+    CUSTOM_COMPONENT_HOME_CONNECT_VERSION=1.4.2 \
       # renovatebot: datasource=github-releases depName=smartHomeHub/SmartIR
     CUSTOM_COMPONENT_SMARTIR_VERSION=1.18.1 \
       # renovatebot: datasource=github-releases depName=eigger/hass-gicisky
-    CUSTOM_COMPONENT_GICISKY_VERSION=5.3.0 \
+    CUSTOM_COMPONENT_GICISKY_VERSION=5.3.2 \
       # renovatebot: datasource=github-releases depName=sca075/mqtt_vacuum_camera
     CUSTOM_COMPONENT_MQTT_VACUUM_CAMERA_VERSION=2026.5.0 \
       # renovatebot: datasource=github-releases depName=PiotrMachowski/lovelace-xiaomi-vacuum-map-card
-    CUSTOM_CARD_XIAOMI_VACUUM_MAP_VERSION=v2.3.2 \
+    CUSTOM_CARD_XIAOMI_VACUUM_MAP_VERSION=v2.4.1 \
       # renovatebot: datasource=github-releases depName=Hypfer/lovelace-valetudo-map-card
     CUSTOM_CARD_VALETUDO_VACUUM_MAP_VERSION=v2023.04.0 \
       # renovatebot: datasource=github-releases depName=dylandoamaral/uptime-card


### PR DESCRIPTION
Top of the stack, layer 4 of 4. Targets #503.

Three patch-level bumps, no breaking changes in any of them:

| Component | From | To | Change |
|---|---|---|---|
| `ekutner/home-connect-hass` | 1.4.1 | **1.4.2** | Removes the advanced options gating that HA 2026.6 made unnecessary; accepts a delayed operation in select program even when missing from the available program |
| `eigger/hass-gicisky` | 5.3.0 | **5.3.2** | Clamps battery percentage at 100; fixes negative battery values |
| `lovelace-xiaomi-vacuum-map-card` | v2.3.2 | **v2.4.1** | Fixes broken dropdowns and buttons in the card editor; new vacuum platforms |

These are independent of each other and of the layers below — they are grouped here only to keep the stack linear over the same `Dockerfile`.

### Everything else is already current

The remaining 15 pinned components were each checked against upstream and are on their latest stable release: `edata`, `SmartIR`, `mqtt_vacuum_camera`, `google_home`, `xiaomi_cloud_map_extractor`, `dyson`, `delete_file`, `apexcharts`, `uptime-card`, `mini-graph-card`, `mushroom`, `valetudo-map-card`, `tv-card`, `google_home_timers_card`, `browser_mod` (bumped in #503).

Three have newer versions that are **prereleases only** and were deliberately left alone: mushroom (`v5.2.0`), mini-graph-card (`v0.14.0-dev.1`), xiaomi-cloud-map-extractor (`v3.0.0` alphas).

### Unrelated finding

`ha-dyson` is pinned to `v1.7.0`, which is the newest *tag*, but the newest published *release* is `v1.5.7`. Renovate queries it with `datasource=github-releases`, so it will never propose an update for this pin. Not urgent, but that dependency is currently invisible to the bot — switching it to `github-tags` would fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)