### PR TITLE
feat(immich): group all Immich component updates into a single Renovate PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,53 @@
         'docker'
       ],
       enabled: false
+    },
+    {
+      // Immich ships as a single release and running mixed versions is
+      // unsupported, so everything under immich/ lands in one PR merged as a
+      // unit. separateMajorMinor stays at its default (true) on purpose: a
+      // major goes to renovate_cron/major-immich and does not block the
+      // minor/patch PRs for the current major.
+      matchFileNames: [
+        'immich/**'
+      ],
+      groupName: 'immich stack',
+      groupSlug: 'immich',
+      // Immich ships hotfixes quickly; wait before proposing a release.
+      minimumReleaseAge: '3 days',
+      prBodyNotes: [
+        ':warning: Read the Immich release notes before merging: releases can ship breaking changes and database migrations, and downgrading is not supported. Merge the PR whole or not at all — server and machine-learning must run the same version.'
+      ]
+    },
+    {
+      // Postgres/Valkey digests are copied from the Immich release compose, so a
+      // standalone digest refresh carries no compatibility guarantee and is not
+      // worth a PR. Tag changes still open one. Sync digests by hand from
+      // https://github.com/immich-app/immich/blob/main/docker/docker-compose.yml
+      matchFileNames: [
+        'immich/**'
+      ],
+      matchPackageNames: [
+        'ghcr.io/immich-app/postgres',
+        'ghcr.io/valkey-io/valkey'
+      ],
+      matchUpdateTypes: [
+        'digest'
+      ],
+      enabled: false
+    },
+    {
+      // Tracked through github-releases (see custom managers) so the PR carries
+      // release notes and every image resolves to the same version. Drop the
+      // duplicate deps the built-in docker manager finds on those lines.
+      matchDatasources: [
+        'docker'
+      ],
+      matchPackageNames: [
+        'ghcr.io/immich-app/immich-server',
+        'ghcr.io/immich-app/immich-machine-learning'
+      ],
+      enabled: false
     }
   ],
   
@@ -97,6 +144,21 @@
         'image: ghcr.io/crocodilestick/calibre-web-automated:(?<currentValue>[^ ]*)\\n'
       ],
       depNameTemplate: 'crocodilestick/calibre-web-automated',
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'semver-coerced'
+    },
+    {
+      // Remote ROCm image: same github-releases entry as immich-server. The
+      // generic manager above can't be used because it would capture "-rocm" as
+      // part of the version; here only the version part is captured.
+      customType: 'regex',
+      managerFilePatterns: [
+        '/immich/remote-ml/docker-compose.yml/'
+      ],
+      matchStrings: [
+        'image: ghcr\\.io/immich-app/immich-machine-learning:(?<currentValue>[^\\s@-]+)-rocm'
+      ],
+      depNameTemplate: 'immich-app/immich',
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'semver-coerced'
     },

--- a/.github/workflows/home_assistant.yaml
+++ b/.github/workflows/home_assistant.yaml
@@ -14,7 +14,7 @@ jobs:
     #   image: homeassistant/home-assistant:0.104.3
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Prepare privates
         run: |
           set -ex

--- a/.github/workflows/renovate-validate.yml
+++ b/.github/workflows/renovate-validate.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate repository config (renovate.json5)
         run: |
           echo "🔍 Validating repository configuration file..."
           docker run --rm -v "$PWD":/tmp -w /tmp \
-            renovate/renovate:41 \
+            renovate/renovate:43 \
             renovate-config-validator \
             --strict \
             .github/renovate.json5
@@ -54,7 +54,7 @@ jobs:
             -e RENOVATE_CONFIG_FILE="/tmp/.github/renovate.global.js" \
             -v "$PWD":/tmp \
             -w /tmp \
-            renovate/renovate:41 \
+            renovate/renovate:43 \
             --platform=github \
             --dry-run=full \
             ManuelLR/MomaHome || {

--- a/immich/README.md
+++ b/immich/README.md
@@ -30,3 +30,9 @@ before `immich-server` answers. The first account registered becomes the admin.
   database dumps Immich writes to `library/backups`. Never copy
   `/data/immich/postgres` hot. RAID1 is redundancy, not a backup.
 - **Merge Immich updates by hand** — releases can ship breaking changes.
+  Renovate opens one grouped PR covering the server and both machine-learning
+  images; a major release gets its own PR, so patches for the current major keep
+  flowing while it waits.
+- **Postgres and Valkey digests are pinned, not tracked.** Copy them from the
+  [Immich release compose](https://github.com/immich-app/immich/blob/main/docker/docker-compose.yml)
+  when a release changes them.

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     # container (v3 merged the old "microservices" service into the server).
     # Only this service is routed through Traefik; the rest stay on the internal
     # network. Pinned to a release tag so Renovate tracks new Immich releases.
-    # renovatebot: datasource=github-releases depName=immich-app/immich
+    # extractVersion keeps the leading "v": Immich only publishes v-prefixed tags.
+    # renovatebot: datasource=github-releases depName=immich-app/immich extractVersion=^(?<version>.+)$
     image: ghcr.io/immich-app/immich-server:v3.0.2
     restart: unless-stopped
     env_file:
@@ -50,7 +51,7 @@ services:
     # CLIP smart search + facial recognition. Runs on CPU (the AMD Vega gfx902
     # iGPU is not supported by ROCm). Memory-capped so a processing spike can't
     # OOM the rest of the shared server.
-    # renovatebot: datasource=github-releases depName=immich-app/immich
+    # renovatebot: datasource=github-releases depName=immich-app/immich extractVersion=^(?<version>.+)$
     image: ghcr.io/immich-app/immich-machine-learning:v3.0.2
     restart: unless-stopped
     env_file:
@@ -63,9 +64,11 @@ services:
       - internal
 
   redis:
-    # Valkey (Redis-compatible) for the job queue. Image + digest copied verbatim
-    # from the official Immich release compose so it moves in lockstep with Immich.
-    image: docker.io/valkey/valkey:9@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
+    # Valkey (Redis-compatible) for the job queue. Digest copied verbatim from the
+    # official Immich release compose so it moves in lockstep with Immich. Pulled
+    # from GHCR instead of upstream's Docker Hub reference (same manifest, same
+    # digest) to keep the stack on one registry, off Docker Hub's pull limits.
+    image: ghcr.io/valkey-io/valkey:9@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping || exit 1"]
@@ -82,7 +85,10 @@ services:
     # (PG >=14 <20, VectorChord >=0.3 <2.0, pgvector >=0.7 <0.9), and picking the
     # newest supported PG major avoids a major DB migration down the line.
     # NOTE: not a plain postgres image — needs the vector extensions to boot.
-    # renovatebot: datasource=docker depName=immich-app/postgres registryUrl=https://ghcr.io versioning=loose
+    # No renovatebot annotation: no GitHub release feed, and the built-in docker
+    # manager already treats "-vectorchord…-pgvector…" as a suffix and only offers
+    # tags with the same extension combination. Digest updates are disabled in
+    # .github/renovate.json5; sync the digest by hand from the Immich release compose.
     image: ghcr.io/immich-app/postgres:18-vectorchord1.1.1-pgvector0.8.5@sha256:e0b09660f2848fc32b5fa4a58936ddf1991efa7d03b9f043ff426a39f480ab47
     restart: unless-stopped
     shm_size: 128mb

--- a/immich/remote-ml/docker-compose.yml
+++ b/immich/remote-ml/docker-compose.yml
@@ -9,8 +9,9 @@ name: immich_remote_ml
 services:
   immich-machine-learning:
     # ROCm (GPU) build. MUST stay on the same Immich version as the
-    # immich-server. Renovate's built-in docker manager tracks the "-rocm" tag
-    # (it keeps the suffix and bumps the version part).
+    # immich-server. A custom manager in .github/renovate.json5 bumps only the
+    # version part from the same github-releases entry as the server, inside the
+    # grouped "immich stack" PR.
     image: ghcr.io/immich-app/immich-machine-learning:v3.0.2-rocm
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Immich only supports running its components on matching versions, so this makes Renovate propose them together instead of one PR per image.

## What changes

- **Grouping.** Everything under `immich/` is grouped as `immich stack`. `separateMajorMinor` is deliberately left at its default, so a major release goes to `renovate_cron/major-immich` and does **not** block the minor/patch PRs for the current major — you keep getting patches while you find time to test the major.
- **ROCm image.** The remote machine-learning image is now tracked through the same `github-releases` entry as the server via a dedicated custom manager that captures only the version part and leaves the `-rocm` suffix alone. The duplicate deps the built-in docker manager found on those same lines are disabled.
- **Bug fix.** The Immich annotations relied on the generic manager default `extractVersion`, which strips the leading `v`. Immich only publishes v-prefixed tags (`v3.0.3` → 200, `3.0.3` → 404 on GHCR), so the first Renovate PR would have written a tag that does not exist.
- **Postgres / Valkey digests.** Standalone digest updates are disabled: those digests are copied from the Immich release compose, so refreshing one on its own carries no compatibility guarantee. Tag changes still open a PR. Sync digests by hand from the [upstream compose](https://github.com/immich-app/immich/blob/main/docker/docker-compose.yml).
- **Registry.** Valkey now comes from GHCR instead of Docker Hub — same manifest and same digest, verified — keeping the stack on one registry and off Docker Hub anonymous pull limits.
- **Postgres annotation removed.** `versioning=loose` was wrong for a tag like `18-vectorchord1.1.1-pgvector0.8.5`; the built-in docker manager already treats the extension part as a suffix and only offers tags with the same combination.
- `actions/checkout` → v7 and `renovate/renovate` → `:43` in the workflows that trigger on push/pull_request.

## Verification

`renovate-config-validator --strict` passes under both Renovate 41 and 43, and a local `--platform=local --dry-run=full` run produces a single `renovate_cron/immich` branch containing the server, the local ML image and the remote ROCm image, all resolving to the same version with the `v` preserved, and no standalone digest branches.

Supersedes #497 and #498.

The Renovate 43 / action v46 bump is intentionally **not** here — the scheduled run only executes from the default branch, so it goes to `master` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)