### PR TITLE
chore(deps): update Renovate to 43.281.0 and the action to v46.1.20

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -13,16 +13,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RENOVATE_VERSION: 41.131.7 # renovate: datasource=docker depName=renovate packageName=ghcr.io/renovatebot/renovate
+  RENOVATE_VERSION: 43.281.0 # renovate: datasource=docker depName=renovate packageName=ghcr.io/renovatebot/renovate
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v43.0.20
+        uses: renovatebot/github-action@v46.1.20
         with:
           renovate-version: ${{ env.RENOVATE_VERSION }}
           # Use the global configuration file that it's going to load the specific repo config file.


### PR DESCRIPTION
Targets `master` on purpose: GitHub only runs `schedule` triggers from the default branch, and uses the workflow file as it exists there — so this bump does nothing while it lives on `next`.

- `renovate` 41.131.7 → 43.281.0
- `renovatebot/github-action` v43.0.20 → v46.1.20 — checked that it still exposes the `configurationFile`, `token` and `renovate-version` inputs; its own default `renovate-version` is already `43`, so the pin is aligned with the action
- `actions/checkout` v4 → v7

## Verification

The repository config was validated against Renovate 43 (`renovate-config-validator --strict` passes) and a local `--platform=local --dry-run=full` run produces the same set of branches under 43 as under 41.

The rest of the changes — the Immich grouping and the `actions/checkout` / `renovate/renovate:43` bumps in the event-triggered workflows — are in #505 against `next`, which does not touch this file, so merging `next` → `master` later will not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)