### PR TITLE
fix(immich): transcode on CPU, h264_vaapi hangs and wedges the queue

### DIFF
--- a/immich/README.md
+++ b/immich/README.md
@@ -26,6 +26,12 @@ before `immich-server` answers. The first account registered becomes the admin.
   cannot be reused.
 - **`immich-config.json`** is a partial, version-controlled config. The keys it
   defines become read-only in the admin UI.
+- **Video transcoding runs on CPU, not the iGPU.** `h264_vaapi` hangs on this
+  hardware (see the comment in `docker-compose.yml`), and a hung ffmpeg blocks
+  the `videoConversion` queue indefinitely because Immich never times it out.
+  If the queue ever shows a job stuck as *Active* for hours, check for a
+  long-running ffmpeg with `docker top immich-immich-server-1` and kill it —
+  the job then moves to *failed* and the queue drains.
 - **Back up `/data/immich/library`**: it holds the originals *and* the daily
   database dumps Immich writes to `library/backups`. Never copy
   `/data/immich/postgres` hot. RAID1 is redundancy, not a backup.

--- a/immich/docker-compose.yml
+++ b/immich/docker-compose.yml
@@ -22,8 +22,14 @@ services:
       - /data/immich/library:/data
       - ./immich-config.json:/config/immich-config.json:ro
       - /etc/localtime:/etc/localtime:ro
-    # Hardware transcoding via VAAPI on the AMD Raven Ridge iGPU (renderD128).
-    # The GPU does H.264/HEVC decode and H.264 encode; ML stays on CPU.
+    # /dev/dri is still passed through, but hardware transcoding is OFF:
+    # immich-config.json sets ffmpeg.accel=disabled. The h264_vaapi encoder on
+    # this Raven Ridge iGPU hangs at 100% CPU on the first frame instead of
+    # failing, and since videoConversion runs with concurrency 1 that wedges the
+    # whole queue for as long as the container stays up (it did, for 15 days).
+    # Reproduce before re-enabling: encoding a 664x486 clip with h264_vaapi
+    # produces a 48-byte file and never returns; the same clip on libx264 takes
+    # under a second. The device stays mapped so re-enabling is a config change.
     devices:
       - /dev/dri:/dev/dri
     group_add:

--- a/immich/immich-config.json
+++ b/immich/immich-config.json
@@ -7,8 +7,8 @@
     }
   },
   "ffmpeg": {
-    "accel": "vaapi",
-    "accelDecode": true,
+    "accel": "disabled",
+    "accelDecode": false,
     "targetVideoCodec": "h264",
     "transcode": "required"
   },


### PR DESCRIPTION
## Problema

La cola `videoConversion` llevaba **15 días bloqueada**: 1 job en *Active* y 198 esperando, sin avanzar.

El job activo era un `ffmpeg` **vivo**, al 99,6% de CPU, que había escrito **48 bytes** (solo la caja `ftyp`) y nunca progresó:

```
2020968  14-19:52:34  99.6%  ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi ... -c:v h264_vaapi ...
```

Arrancó 44 s después de levantar el contenedor y se colgó en el primer frame. No falla — **gira en vacío**, así que Immich nunca lo da por muerto. Con `videoConversion` a concurrencia 1, eso congela toda la cola mientras el contenedor siga arriba.

## Causa

El asset era un clip de motion photo de 2,4 s, 664x486, HEVC. `ffprobe` lo lee sin un solo error: **el fichero está sano**. Probado sobre ese mismo clip:

| Prueba | Resultado |
|---|---|
| decode CPU + encode `h264_vaapi` | **cuelga**, salida de 48 bytes, matado a los 90 s |
| `libx264`, mismo input | **0,88 s**, 512 KB, correcto |

O sea: el problema es el **encoder** VAAPI, no el decoder. `accelDecode: false` no habría arreglado nada.

Además la cola de extracción de motion photos sigue funcionando y **alimentando** la de videoConversion, por eso el backlog crecía.

## Solución

- `ffmpeg.accel: "disabled"` — transcodificación por CPU. Son clips de 2-3 s que `libx264` resuelve en menos de un segundo, el coste real es despreciable.
- **`videoConversion.concurrency` se queda en 1.** Subirlo no daría throughput por CPU (mismos cores, repartidos) y woody los comparte con ~20 servicios más.
- `/dev/dri` sigue mapeado, así que reactivar la GPU es un cambio de config, no un redespliegue.
- Documentado en el `README` cómo detectar y desatascar el síntoma si reaparece.

## Despliegue

```bash
cd /data/app/MomaHome/immich
git pull
docker compose restart immich-server
```

`restart`, **no `up -d`**: los contenedores en marcha son de un compose anterior y un `up -d` recrearía Redis, que al no tener volumen se llevaría los 198 jobs de la cola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)