### PR TITLE
feat(home_assistant): add EMASESA Water panel and leak automation

### DIFF
--- a/home_automation/home_assistant/config/__auto_generated-config/automation/emasesa.yaml
+++ b/home_automation/home_assistant/config/__auto_generated-config/automation/emasesa.yaml
@@ -1,0 +1,1 @@
+../../packages/emasesa/automation.yaml

--- a/home_automation/home_assistant/config/packages/emasesa/automation.yaml
+++ b/home_automation/home_assistant/config/packages/emasesa/automation.yaml
@@ -1,6 +1,6 @@
 # automation:
 
-  - alias: AUT-EMASESA Posible fuga detectada
+  - alias: AUT-EMASESA Possible leak detected
     id: aut_emasesa_posible_fuga
     initial_state: 'on'
     triggers:
@@ -11,8 +11,8 @@
       - action: script.telegram_notify
         data:
           target_person: all
-          title: "🚰 Posible fuga de agua"
+          title: "🚰 Possible water leak"
           message: >
-            Se ha detectado consumo continuo en madrugada durante varias noches.
-            Revisa el contador y las instalaciones.
-            Consumo mínimo nocturno: {{ state_attr('binary_sensor.emasesa_posible_fuga', 'consumo_minimo_nocturno_l') | round(1) }} L/h.
+            Continuous water usage detected during the early hours over several nights.
+            Check the meter and plumbing.
+            Minimum overnight consumption: {{ state_attr('binary_sensor.emasesa_posible_fuga', 'consumo_minimo_nocturno_l') | round(1) }} L/h.

--- a/home_automation/home_assistant/config/packages/emasesa/automation.yaml
+++ b/home_automation/home_assistant/config/packages/emasesa/automation.yaml
@@ -1,0 +1,18 @@
+# automation:
+
+  - alias: AUT-EMASESA Posible fuga detectada
+    id: aut_emasesa_posible_fuga
+    initial_state: 'on'
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.emasesa_posible_fuga
+        to: 'on'
+    actions:
+      - action: script.telegram_notify
+        data:
+          target_person: all
+          title: "🚰 Posible fuga de agua"
+          message: >
+            Se ha detectado consumo continuo en madrugada durante varias noches.
+            Revisa el contador y las instalaciones.
+            Consumo mínimo nocturno: {{ state_attr('binary_sensor.emasesa_posible_fuga', 'consumo_minimo_nocturno_l') | round(1) }} L/h.

--- a/home_automation/home_assistant/config/ui-views/Water.yaml
+++ b/home_automation/home_assistant/config/ui-views/Water.yaml
@@ -1,0 +1,113 @@
+# NOTA: los entity_id a continuación siguen el patrón confirmado por
+# sensor.emasesa_consumo_medio_diario. Ajústalos si tu instalación genera
+# IDs distintos (depende del nombre del dispositivo en HA).
+
+- type: vertical-stack
+  cards:
+    # ── Resumen rápido ──────────────────────────────────────────────────────
+    - type: horizontal-stack
+      cards:
+        - type: custom:mushroom-entity-card
+          entity: sensor.emasesa_consumo_del_dia
+          name: Consumo hoy
+          icon: mdi:water
+          primary_info: state
+          secondary_info: last-updated
+          tap_action:
+            action: more-info
+        - type: custom:mushroom-entity-card
+          entity: sensor.emasesa_consumo_medio_diario
+          name: Consumo medio
+          icon: mdi:chart-line
+          primary_info: state
+          secondary_info: attribute
+          attribute: valoracion_texto
+          tap_action:
+            action: more-info
+        - type: custom:mushroom-entity-card
+          entity: sensor.emasesa_coste_del_periodo
+          name: Coste periodo
+          icon: mdi:cash
+          primary_info: state
+          secondary_info: attribute
+          attribute: periodo_desde
+          tap_action:
+            action: more-info
+
+    # ── Facturación ─────────────────────────────────────────────────────────
+    - type: horizontal-stack
+      cards:
+        - type: entity
+          entity: sensor.emasesa_ultima_factura
+          name: Última factura
+        - type: entity
+          entity: sensor.emasesa_importe_pendiente
+          name: Importe pendiente
+        - type: entity
+          entity: sensor.emasesa_dias_para_la_proxima_factura
+          name: Próxima factura en
+
+    # ── Consumo diario — últimos 30 días ────────────────────────────────────
+    - type: custom:mini-graph-card
+      name: Consumo diario (30 días)
+      entities:
+        - entity: sensor.emasesa_consumo_del_dia
+          name: Litros
+      hours_to_show: 720
+      group_by: date
+      aggregate_func: max
+      line_color: '#2196F3'
+      bar_chart: true
+      show:
+        extrema: true
+        legend: false
+        state: true
+
+    # ── Consumo acumulado semanal (estadística HA) ───────────────────────────
+    - type: statistics-graph
+      title: Consumo semanal (m³)
+      entities:
+        - entity: sensor.emasesa_indice_del_contador
+          name: Contador
+      days_to_show: 90
+      period: week
+      stat_types:
+        - change
+
+    # ── Embalses ─────────────────────────────────────────────────────────────
+    - type: entity
+      entity: sensor.emasesa_embalses
+      name: Nivel embalses (Sevilla)
+      icon: mdi:waves
+    - type: custom:mini-graph-card
+      name: Evolución nivel embalses
+      entities:
+        - entity: sensor.emasesa_embalses
+          name: Nivel (%)
+      hours_to_show: 8760
+      group_by: week
+      aggregate_func: last
+      line_color: '#03A9F4'
+      show:
+        extrema: true
+        fill: true
+
+    # ── Alertas / estado ─────────────────────────────────────────────────────
+    - type: entities
+      title: Estado y alertas
+      entities:
+        - entity: binary_sensor.emasesa_posible_fuga
+          name: Posible fuga
+          icon: mdi:water-alert
+        - entity: binary_sensor.emasesa_incidencia_de_red_cercana
+          name: Incidencia de red cercana
+          icon: mdi:pipe-leak
+        - entity: binary_sensor.emasesa_averia_del_contador
+          name: Avería del contador
+          icon: mdi:counter
+        - entity: binary_sensor.emasesa_incidencia_pendiente
+          name: Incidencia pendiente
+          icon: mdi:wrench-clock
+        - entity: sensor.emasesa_precio_del_agua
+          name: Precio actual (€/m³)
+          icon: mdi:cash-multiple

--- a/home_automation/home_assistant/config/ui-views/Water.yaml
+++ b/home_automation/home_assistant/config/ui-views/Water.yaml
@@ -1,15 +1,14 @@
-# NOTA: los entity_id a continuación siguen el patrón confirmado por
-# sensor.emasesa_consumo_medio_diario. Ajústalos si tu instalación genera
-# IDs distintos (depende del nombre del dispositivo en HA).
+# NOTE: entity IDs follow the confirmed pattern sensor.emasesa_consumo_medio_diario.
+# Adjust them if your installation generates different IDs (depends on the HA device name).
 
 - type: vertical-stack
   cards:
-    # ── Resumen rápido ──────────────────────────────────────────────────────
+    # ── Quick summary ────────────────────────────────────────────────────────
     - type: horizontal-stack
       cards:
         - type: custom:mushroom-entity-card
           entity: sensor.emasesa_consumo_del_dia
-          name: Consumo hoy
+          name: Today's consumption
           icon: mdi:water
           primary_info: state
           secondary_info: last-updated
@@ -17,7 +16,7 @@
             action: more-info
         - type: custom:mushroom-entity-card
           entity: sensor.emasesa_consumo_medio_diario
-          name: Consumo medio
+          name: Daily average
           icon: mdi:chart-line
           primary_info: state
           secondary_info: attribute
@@ -26,7 +25,7 @@
             action: more-info
         - type: custom:mushroom-entity-card
           entity: sensor.emasesa_coste_del_periodo
-          name: Coste periodo
+          name: Period cost
           icon: mdi:cash
           primary_info: state
           secondary_info: attribute
@@ -34,25 +33,25 @@
           tap_action:
             action: more-info
 
-    # ── Facturación ─────────────────────────────────────────────────────────
+    # ── Billing ──────────────────────────────────────────────────────────────
     - type: horizontal-stack
       cards:
         - type: entity
           entity: sensor.emasesa_ultima_factura
-          name: Última factura
+          name: Last invoice
         - type: entity
           entity: sensor.emasesa_importe_pendiente
-          name: Importe pendiente
+          name: Outstanding amount
         - type: entity
           entity: sensor.emasesa_dias_para_la_proxima_factura
-          name: Próxima factura en
+          name: Next invoice in
 
-    # ── Consumo diario — últimos 30 días ────────────────────────────────────
+    # ── Daily consumption — last 30 days ─────────────────────────────────────
     - type: custom:mini-graph-card
-      name: Consumo diario (30 días)
+      name: Daily consumption (30 days)
       entities:
         - entity: sensor.emasesa_consumo_del_dia
-          name: Litros
+          name: Litres
       hours_to_show: 720
       group_by: date
       aggregate_func: max
@@ -63,27 +62,27 @@
         legend: false
         state: true
 
-    # ── Consumo acumulado semanal (estadística HA) ───────────────────────────
+    # ── Weekly accumulated consumption (HA statistics) ───────────────────────
     - type: statistics-graph
-      title: Consumo semanal (m³)
+      title: Weekly consumption (m³)
       entities:
         - entity: sensor.emasesa_indice_del_contador
-          name: Contador
+          name: Meter
       days_to_show: 90
       period: week
       stat_types:
         - change
 
-    # ── Embalses ─────────────────────────────────────────────────────────────
+    # ── Reservoirs ───────────────────────────────────────────────────────────
     - type: entity
       entity: sensor.emasesa_embalses
-      name: Nivel embalses (Sevilla)
+      name: Reservoir level (Seville)
       icon: mdi:waves
     - type: custom:mini-graph-card
-      name: Evolución nivel embalses
+      name: Reservoir level history
       entities:
         - entity: sensor.emasesa_embalses
-          name: Nivel (%)
+          name: Level (%)
       hours_to_show: 8760
       group_by: week
       aggregate_func: last
@@ -92,22 +91,22 @@
         extrema: true
         fill: true
 
-    # ── Alertas / estado ─────────────────────────────────────────────────────
+    # ── Alerts / status ──────────────────────────────────────────────────────
     - type: entities
-      title: Estado y alertas
+      title: Status & alerts
       entities:
         - entity: binary_sensor.emasesa_posible_fuga
-          name: Posible fuga
+          name: Possible leak
           icon: mdi:water-alert
         - entity: binary_sensor.emasesa_incidencia_de_red_cercana
-          name: Incidencia de red cercana
+          name: Nearby network incident
           icon: mdi:pipe-leak
         - entity: binary_sensor.emasesa_averia_del_contador
-          name: Avería del contador
+          name: Meter fault
           icon: mdi:counter
         - entity: binary_sensor.emasesa_incidencia_pendiente
-          name: Incidencia pendiente
+          name: Pending incident
           icon: mdi:wrench-clock
         - entity: sensor.emasesa_precio_del_agua
-          name: Precio actual (€/m³)
+          name: Water price (€/m³)
           icon: mdi:cash-multiple

--- a/home_automation/home_assistant/config/ui-views/_ui-views.yaml
+++ b/home_automation/home_assistant/config/ui-views/_ui-views.yaml
@@ -11,6 +11,9 @@
 - title: Energy
   icon: mdi:home-lightning-bolt-outline
   cards: !include Energy.yaml
+- title: Water
+  icon: mdi:water
+  cards: !include Water.yaml
 - title: Environment
   icon: mdi:thermometer-water
   cards: !include Environment.yaml


### PR DESCRIPTION
## Summary

Follow-up to #520. Adds the UI panel and automation for the EMASESA integration.

- `ui-views/Water.yaml` — new Water view with daily consumption chart (mini-graph, 30d), weekly accumulated stats (statistics-graph), reservoir level history, and a status/alerts card
- `ui-views/_ui-views.yaml` — registers the Water view between Energy and Environment
- `packages/emasesa/automation.yaml` — notifies both users via `script.telegram_notify` when `binary_sensor.emasesa_posible_fuga` turns on

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fezq5Gs9qttzuXaV3WWub1)_